### PR TITLE
Switch to pty.fork() for subprocess cration to have full control over the I/O

### DIFF
--- a/scripts/prefect/run_scmultiplex
+++ b/scripts/prefect/run_scmultiplex
@@ -1,5 +1,14 @@
 #!/usr/bin/env python3
 
+# Copyright (C) 2023 Friedrich Miescher Institute for Biomedical Research
+
+##############################################################################
+#                                                                            #
+# Author: Nicole Repina              <nicole.repina@fmi.ch>                  #
+# Author: Enrico Tagliavini          <enrico.tagliavini@fmi.ch>              #
+#                                                                            #
+##############################################################################
+
 import argparse
 import io
 import os


### PR DESCRIPTION
To have the full output of the tasks logged to both console and log file at the same time the best approach seems to be using the `pty.fork()` systemcall (the original being `forkpty()`). 