### PR TITLE
Extract morphology measurements only on segmentation channel.

### DIFF
--- a/scripts/prefect/01_feature_extraction.py
+++ b/scripts/prefect/01_feature_extraction.py
@@ -92,8 +92,9 @@ def get_organoids(
 
 @task()
 def organoid_feature_extraction_and_linking_task(
-    organoid, nuc_ending: str, mem_ending: str, mask_ending: str, spacing: List[float], org_seg_ch, nuc_seg_ch, mem_seg_ch, ovr_channel, iop_cutoff
-    ):
+    organoid, nuc_ending: str, mem_ending: str, mask_ending: str, spacing: List[float],
+        org_seg_ch, nuc_seg_ch, mem_seg_ch, ovr_channel, iop_cutoff):
+
     set_spacing(spacing)
     extract_organoid_features(
         organoid=organoid,
@@ -102,6 +103,9 @@ def organoid_feature_extraction_and_linking_task(
         mask_ending=mask_ending,
         spacing=tuple(spacing),
         measure_morphology=True,
+        organoid_seg_channel=org_seg_ch,
+        nuclear_seg_channel=nuc_seg_ch,
+        membrane_seg_channel=mem_seg_ch,
     )
     link_nuc_to_membrane(
         organoid=organoid,
@@ -112,6 +116,7 @@ def organoid_feature_extraction_and_linking_task(
         iop_cutoff=iop_cutoff,
     )
     return
+
 
 # all feature extraction in one flow because writing to the same json file
 def run_flow(r_params, cpus):

--- a/src/scmultiplex/features/FeatureExtraction.py
+++ b/src/scmultiplex/features/FeatureExtraction.py
@@ -33,14 +33,15 @@ def extract_organoid_features(
     mask_ending: str,
     spacing: Tuple[float],
     measure_morphology,
+    organoid_seg_channel,
+    nuclear_seg_channel,
+    membrane_seg_channel,
 ):
     nuc_seg = organoid.get_segmentation(nuc_ending)  # load segmentation images
     mem_seg = organoid.get_segmentation(mem_ending)  # load segmentation images
     org_seg = organoid.get_segmentation(mask_ending)
 
-
     # for each raw image, extract organoid-level features
-    first_channel = True
 
     for channel in organoid.raw_files:
 
@@ -56,7 +57,7 @@ def extract_organoid_features(
 
         abs_min_intensity = np.amin(raw_mip)
 
-        calc_morphology = first_channel and measure_morphology
+        calc_morphology = (channel == organoid_seg_channel) and measure_morphology
 
         extra_values_common = {'hcs_experiment': organoid.well.plate.experiment.name,
                                'root_dir': organoid.well.plate.experiment.root_dir,
@@ -71,6 +72,7 @@ def extract_organoid_features(
             'object_type': 'organoid',
             'abs_min': abs_min_intensity,
         }
+
 
         measure_features(
             object_type = 'org',
@@ -90,6 +92,7 @@ def extract_organoid_features(
 
         # NUCLEAR feature extraction
         if nuc_seg is not None:
+            calc_morphology = (channel == nuclear_seg_channel) and measure_morphology
 
             extra_values_nuc = {
                 'segmentation_nuc': organoid.segmentations[nuc_ending],
@@ -119,6 +122,7 @@ def extract_organoid_features(
 
         # MEMBRANE feature extraction
         if mem_seg is not None:
+            calc_morphology = (channel == membrane_seg_channel) and measure_morphology
 
             extra_values_mem = {
                 'segmentation_mem': organoid.segmentations[mem_ending],
@@ -144,8 +148,6 @@ def extract_organoid_features(
                 extra_values_object=extra_values_mem,
                 touching_labels=None,
             )
-
-        first_channel = False
 
     return
 


### PR DESCRIPTION
Previously was extracting morphology on first channel of for loop, which can vary.