### PR TITLE
Improve feature wrapper and fractal task

### DIFF
--- a/src/scmultiplex/features/feature_wrapper.py
+++ b/src/scmultiplex/features/feature_wrapper.py
@@ -147,20 +147,20 @@ def get_intensity_measurements(labeled_obj, channel_prefix, spacing, is_2D):
         "kurtosis": labeled_obj["kurtos"],
         # "x_pos_weighted_pix": labeled_obj["weighted_centroid"][-1],
         # "y_pos_weighted_pix": labeled_obj["weighted_centroid"][-2],
-        "x_massDisp_pix": labeled_obj["weighted_centroid"][-1]
-        - labeled_obj["centroid"][-1],
-        "y_massDisp_pix": labeled_obj["weighted_centroid"][-2]
-        - labeled_obj["centroid"][-2],
+        # "x_massDisp_pix": labeled_obj["weighted_centroid"][-1]
+        # - labeled_obj["centroid"][-1],
+        # "y_massDisp_pix": labeled_obj["weighted_centroid"][-2]
+        # - labeled_obj["centroid"][-2],
     }
 
     # add 3D-specific intensity measurements
-    if not is_2D:
-        intensity_3D_only = {
-            # "z_pos_weighted_pix": labeled_obj["weighted_centroid"][-3],
-            "z_massDisp_pix": labeled_obj["weighted_centroid"][-3]
-            - labeled_obj["centroid"][-3],
-        }
-        intensity_measurements.update(intensity_3D_only)
+    # if not is_2D:
+    #     intensity_3D_only = {
+    #         "z_pos_weighted_pix": labeled_obj["weighted_centroid"][-3],
+    #         "z_massDisp_pix": labeled_obj["weighted_centroid"][-3]
+    #         - labeled_obj["centroid"][-3],
+    #     }
+    #     intensity_measurements.update(intensity_3D_only)
 
     # New centroid weighting block
     if True:

--- a/src/scmultiplex/features/feature_wrapper.py
+++ b/src/scmultiplex/features/feature_wrapper.py
@@ -124,10 +124,10 @@ def get_regionprops_measurements(
         if measure_morphology:
             morphology_measurements = {
                 "is_touching_border_xy": is_touching_border_xy(
-                    labeled_obj, img_shape=img.shape
+                    labeled_obj, img_shape=label_img.shape
                 ),
-                "imgdim_x": img.shape[-1],
-                "imgdim_y": img.shape[-2],
+                "imgdim_x": label_img.shape[-1],
+                "imgdim_y": label_img.shape[-2],
                 "area_bbox": labeled_obj["area_bbox"],
                 "area_convhull": labeled_obj["area_convex"],
                 "equivDiam": labeled_obj["equivalent_diameter_area"],

--- a/src/scmultiplex/features/feature_wrapper.py
+++ b/src/scmultiplex/features/feature_wrapper.py
@@ -173,9 +173,9 @@ def get_regionprops_measurements(
                 morphology_measurements.update(morphology_2D_only)
             else:
                 morphology_3d_only = {
-                    "imgdim_z": img.shape[-3],
+                    "imgdim_z": label_img.shape[-3],
                     "is_touching_border_z": is_touching_border_z(
-                        labeled_obj, img_shape=img.shape
+                        labeled_obj, img_shape=label_img.shape
                     ),
                     "volume_pix": labeled_obj["area"],
                     "surface_area": labeled_obj["surface_area_marchingcube"],

--- a/src/scmultiplex/features/feature_wrapper.py
+++ b/src/scmultiplex/features/feature_wrapper.py
@@ -105,126 +105,23 @@ def get_regionprops_measurements(
             "label": int(labeled_obj["label"]),
         }
 
-        # Always include xy positions
-        coordinate_measurements = {
-            "x_pos_pix": labeled_obj["centroid"][-1],
-            "y_pos_pix": labeled_obj["centroid"][-2],
-        }
-
+        # Always include coordinates
+        coordinate_measurements = get_coordinates(labeled_obj, spacing, is_2D)
         label_info.update(coordinate_measurements)
 
-        if not is_2D:
-            coordinate_measurements_3D = {
-                "z_pos_pix_scaled": labeled_obj["centroid"][-3],
-                "z_pos_pix_img": labeled_obj["centroid"][-3]
-                / spacing_anisotropy_scalar(spacing)
-            }
-            label_info.update(coordinate_measurements_3D)
-
         if measure_morphology:
-            morphology_measurements = {
-                "is_touching_border_xy": is_touching_border_xy(
-                    labeled_obj, img_shape=label_img.shape
-                ),
-                "imgdim_x": label_img.shape[-1],
-                "imgdim_y": label_img.shape[-2],
-                "area_bbox": labeled_obj["area_bbox"],
-                "area_convhull": labeled_obj["area_convex"],
-                "equivDiam": labeled_obj["equivalent_diameter_area"],
-                "extent": labeled_obj["extent"],
-                "solidity": labeled_obj["solidity"],
-            }
-            # Sometimes, major & minor axis calculations fail with a
-            # ValueError: math domain error
-            try:
-                morphology_measurements["majorAxisLength"] = labeled_obj[
-                    "major_axis_length"
-                ]
-                morphology_measurements["minorAxisLength"] = labeled_obj[
-                    "minor_axis_length"
-                ]
-                morphology_measurements["minmajAxisRatio"] = minor_major_axis_ratio(
-                    labeled_obj
-                )
-                morphology_measurements[
-                    "aspectRatio_equivalentDiameter"
-                ] = aspect_ratio(labeled_obj)
-            except ValueError:
-                morphology_measurements["majorAxisLength"] = np.NaN
-                morphology_measurements["minorAxisLength"] = np.NaN
-                morphology_measurements["minmajAxisRatio"] = np.NaN
-                morphology_measurements["aspectRatio_equivalentDiameter"] = np.NaN
-
-            if is_2D:
-                morphology_2D_only = {
-                    "area_pix": labeled_obj["area"],
-                    "perimeter": labeled_obj["perimeter"],
-                    "concavity": convex_hull_area_resid(labeled_obj),
-                    "asymmetry": convex_hull_centroid_dif(labeled_obj),
-                    "eccentricity": labeled_obj["eccentricity"],
-                    "circularity": circularity(labeled_obj),
-                    "concavity_count": concavity_count(
-                        labeled_obj, min_area_fraction=min_area_fraction
-                    ),
-                    "disconnected_components": disconnected_component(
-                        labeled_obj.image
-                    ),
-                }
-                morphology_measurements.update(morphology_2D_only)
-            else:
-                morphology_3d_only = {
-                    "imgdim_z": label_img.shape[-3],
-                    "is_touching_border_z": is_touching_border_z(
-                        labeled_obj, img_shape=label_img.shape
-                    ),
-                    "volume_pix": labeled_obj["area"],
-                    "surface_area": labeled_obj["surface_area_marchingcube"],
-                }
-                morphology_measurements.update(morphology_3d_only)
+            morphology_measurements = get_morphology_measurements(
+                labeled_obj, label_img.shape, is_2D, min_area_fraction
+            )
 
             label_info.update(morphology_measurements)
 
         if img is not None:
-            intensity_measurements = {
-                "mean_intensity": labeled_obj["mean_intensity"],
-                "max_intensity": labeled_obj["max_intensity"],
-                "min_intensity": labeled_obj["min_intensity"],
-                "percentile25": labeled_obj["fixed_percentiles"][0],
-                "percentile50": labeled_obj["fixed_percentiles"][1],
-                "percentile75": labeled_obj["fixed_percentiles"][2],
-                "percentile90": labeled_obj["fixed_percentiles"][3],
-                "percentile95": labeled_obj["fixed_percentiles"][4],
-                "percentile99": labeled_obj["fixed_percentiles"][5],
-                "stdev": labeled_obj["stdv"],
-                "skew": labeled_obj["skewness"],
-                "kurtosis": labeled_obj["kurtos"],
-                "x_pos_weighted_pix": labeled_obj["weighted_centroid"][-1],
-                "y_pos_weighted_pix": labeled_obj["weighted_centroid"][-2],
-                "x_massDisp_pix": labeled_obj["weighted_centroid"][-1]
-                - labeled_obj["centroid"][-1],
-                "y_massDisp_pix": labeled_obj["weighted_centroid"][-2]
-                - labeled_obj["centroid"][-2],
-            }
+            intensity_measurements = get_intensity_measurements(
+                labeled_obj, channel_prefix, is_2D
+            )
 
-            # add 3D-specific intensity measurements
-            if not is_2D:
-                intensity_3D_only = {
-                    "z_pos_weighted_pix": labeled_obj["weighted_centroid"][-3],
-                    "z_massDisp_pix": labeled_obj["weighted_centroid"][-3]
-                    - labeled_obj["centroid"][-3],
-                }
-                intensity_measurements.update(intensity_3D_only)
-
-            # channel prefix addition is optional
-            if channel_prefix is not None:
-                intensity_measurements_pref = {
-                    channel_prefix + "." + str(key): val
-                    for key, val in intensity_measurements.items()
-                }
-            else:
-                intensity_measurements_pref = intensity_measurements
-
-            label_info.update(intensity_measurements_pref)
+            label_info.update(intensity_measurements)
 
         measurement_rows.append(label_info)
 
@@ -232,3 +129,126 @@ def get_regionprops_measurements(
     df_obs = pd.DataFrame(observation_rows)
 
     return df_well, df_obs
+
+
+def get_intensity_measurements(labeled_obj, channel_prefix, is_2D):
+    intensity_measurements = {
+        "mean_intensity": labeled_obj["mean_intensity"],
+        "max_intensity": labeled_obj["max_intensity"],
+        "min_intensity": labeled_obj["min_intensity"],
+        "percentile25": labeled_obj["fixed_percentiles"][0],
+        "percentile50": labeled_obj["fixed_percentiles"][1],
+        "percentile75": labeled_obj["fixed_percentiles"][2],
+        "percentile90": labeled_obj["fixed_percentiles"][3],
+        "percentile95": labeled_obj["fixed_percentiles"][4],
+        "percentile99": labeled_obj["fixed_percentiles"][5],
+        "stdev": labeled_obj["stdv"],
+        "skew": labeled_obj["skewness"],
+        "kurtosis": labeled_obj["kurtos"],
+        "x_pos_weighted_pix": labeled_obj["weighted_centroid"][-1],
+        "y_pos_weighted_pix": labeled_obj["weighted_centroid"][-2],
+        "x_massDisp_pix": labeled_obj["weighted_centroid"][-1]
+        - labeled_obj["centroid"][-1],
+        "y_massDisp_pix": labeled_obj["weighted_centroid"][-2]
+        - labeled_obj["centroid"][-2],
+    }
+
+    # add 3D-specific intensity measurements
+    if not is_2D:
+        intensity_3D_only = {
+            "z_pos_weighted_pix": labeled_obj["weighted_centroid"][-3],
+            "z_massDisp_pix": labeled_obj["weighted_centroid"][-3]
+            - labeled_obj["centroid"][-3],
+        }
+        intensity_measurements.update(intensity_3D_only)
+
+    # channel prefix addition is optional
+    if channel_prefix is not None:
+        intensity_measurements_pref = {
+            channel_prefix + "." + str(key): val
+            for key, val in intensity_measurements.items()
+        }
+    else:
+        intensity_measurements_pref = intensity_measurements
+    
+    return intensity_measurements_pref
+
+
+def get_morphology_measurements(labeled_obj, img_shape, is_2D, min_area_fraction):
+    morphology_measurements = {
+        "is_touching_border_xy": is_touching_border_xy(
+            labeled_obj, img_shape=img_shape
+        ),
+        "imgdim_x": img_shape[-1],
+        "imgdim_y": img_shape[-2],
+        "area_bbox": labeled_obj["area_bbox"],
+        "area_convhull": labeled_obj["area_convex"],
+        "equivDiam": labeled_obj["equivalent_diameter_area"],
+        "extent": labeled_obj["extent"],
+        "solidity": labeled_obj["solidity"],
+    }
+    # Sometimes, major & minor axis calculations fail with a
+    # ValueError: math domain error
+    try:
+        morphology_measurements["majorAxisLength"] = labeled_obj[
+            "major_axis_length"
+        ]
+        morphology_measurements["minorAxisLength"] = labeled_obj[
+            "minor_axis_length"
+        ]
+        morphology_measurements["minmajAxisRatio"] = minor_major_axis_ratio(
+            labeled_obj
+        )
+        morphology_measurements[
+            "aspectRatio_equivalentDiameter"
+        ] = aspect_ratio(labeled_obj)
+    except ValueError:
+        morphology_measurements["majorAxisLength"] = np.NaN
+        morphology_measurements["minorAxisLength"] = np.NaN
+        morphology_measurements["minmajAxisRatio"] = np.NaN
+        morphology_measurements["aspectRatio_equivalentDiameter"] = np.NaN
+
+    if is_2D:
+        morphology_2D_only = {
+            "area_pix": labeled_obj["area"],
+            "perimeter": labeled_obj["perimeter"],
+            "concavity": convex_hull_area_resid(labeled_obj),
+            "asymmetry": convex_hull_centroid_dif(labeled_obj),
+            "eccentricity": labeled_obj["eccentricity"],
+            "circularity": circularity(labeled_obj),
+            "concavity_count": concavity_count(
+                labeled_obj, min_area_fraction=min_area_fraction
+            ),
+            "disconnected_components": disconnected_component(
+                labeled_obj.image
+            ),
+        }
+        morphology_measurements.update(morphology_2D_only)
+    else:
+        morphology_3d_only = {
+            "imgdim_z": img_shape[-3],
+            "is_touching_border_z": is_touching_border_z(
+                labeled_obj, img_shape=img_shape
+            ),
+            "volume_pix": labeled_obj["area"],
+            "surface_area": labeled_obj["surface_area_marchingcube"],
+        }
+        morphology_measurements.update(morphology_3d_only)
+
+    return morphology_measurements
+
+def get_coordinates(labeled_obj, spacing, is_2D):
+    coordinate_measurements = {
+        "x_pos_pix": labeled_obj["centroid"][-1],
+        "y_pos_pix": labeled_obj["centroid"][-2],
+    }
+
+    if not is_2D:
+        coordinate_measurements_3D = {
+            "z_pos_pix_scaled": labeled_obj["centroid"][-3],
+            "z_pos_pix_img": labeled_obj["centroid"][-3]
+            / spacing_anisotropy_scalar(spacing)
+        }
+        coordinate_measurements.update(coordinate_measurements_3D)
+
+    return coordinate_measurements

--- a/src/scmultiplex/fractal/run_measurement.py
+++ b/src/scmultiplex/fractal/run_measurement.py
@@ -25,20 +25,20 @@ from scmultiplex_feature_measurements import scmultiplex_measurements
 # metadata_path = "/Users/joel/shares/homeShareFractal/joel/fractal_v1/fractal-demos/examples/server/{artifacts-110}/workflow_000007_job_000006/metadata.json"
 # metadata_path = "/Users/joel/shares/homeShareFractal/joel/fractal_v1/fractal-demos/examples/server/{artifacts-110}/workflow_000007_job_000006/metadata_3D.json"
 
-zarr_path = "/Users/joel/Dropbox/Joel/FMI/Code/fractal/fractal-demos/examples/01_cardio_tiny_dataset/tmp_cardiac-iPSCs/output/"
-metadata_path = "/Users/joel/Dropbox/Joel/FMI/Code/fractal/fractal-demos/examples/server/artifacts/workflow_000001_job_000001/metadata.json" 
+zarr_path = "/Users/joel/Dropbox/Joel/FMI/Code/fractal/fractal-demos/examples/01_cardio_tiny_dataset/tmp_cardiac-tiny-scMultiplex/output/"
+metadata_path = "/Users/joel/Dropbox/Joel/FMI/Code/fractal/fractal-demos/examples/server/artifacts/workflow_000015_job_000015/metadata.json" 
 
 with open(metadata_path) as json_file:
     metadata = json.load(json_file)
 
 
 input_channels = {
-    "C01": {"wavelength_id": "A01_C01"}, 
+    # "C01": {"wavelength_id": "A01_C01"}, 
     # "C02": {"wavelength_id": "A01_C02"}, 
     # "C03": {"wavelength_id": "A02_C03"}, 
 }
 label_image = 'nuclei'
-output_table_name = 'table_scmultiplex_2D_dev-nar'
+output_table_name = 'table_scmultiplex_2D_no_int_img'
 measure_morphology = True
 
 # scmultiplex task running on existing Zarr file:

--- a/src/scmultiplex/fractal/run_measurement.py
+++ b/src/scmultiplex/fractal/run_measurement.py
@@ -33,13 +33,15 @@ with open(metadata_path) as json_file:
 
 
 input_channels = {
-    # "C01": {"wavelength_id": "A01_C01"}, 
+    "C01": {"wavelength_id": "A01_C01"}, 
     # "C02": {"wavelength_id": "A01_C02"}, 
     # "C03": {"wavelength_id": "A02_C03"}, 
 }
 label_image = 'nuclei'
-output_table_name = 'table_scmultiplex_2D_index'
+output_table_name = 'table_scmultiplex_level_00'
 measure_morphology = True
+level = 0
+label_level = 0
 
 # scmultiplex task running on existing Zarr file:
 for component in metadata["image"]:
@@ -51,6 +53,8 @@ for component in metadata["image"]:
         input_ROI_table = "well_ROI_table", #"well_ROI_table", #"FOV_ROI_table",
         input_channels = input_channels,
         label_image = label_image,
+        label_level = label_level,
+        level = level,
         output_table_name = output_table_name,
         measure_morphology = measure_morphology,
     )

--- a/src/scmultiplex/fractal/run_measurement.py
+++ b/src/scmultiplex/fractal/run_measurement.py
@@ -38,7 +38,7 @@ input_channels = {
     # "C03": {"wavelength_id": "A02_C03"}, 
 }
 label_image = 'nuclei'
-output_table_name = 'table_scmultiplex_2D_no_int_img'
+output_table_name = 'table_scmultiplex_2D_index'
 measure_morphology = True
 
 # scmultiplex task running on existing Zarr file:

--- a/src/scmultiplex/fractal/run_measurement.py
+++ b/src/scmultiplex/fractal/run_measurement.py
@@ -38,7 +38,7 @@ input_channels = {
     # "C03": {"wavelength_id": "A02_C03"}, 
 }
 label_image = 'nuclei'
-output_table_name = 'table_scmultiplex_level_00'
+output_table_name = 'table_scmultiplex_refactor'
 measure_morphology = True
 level = 0
 label_level = 0

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -366,6 +366,7 @@ if __name__ == "__main__":
         level: int
         label_level: int
         measure_morphology: bool
+        allow_duplicate_labels: bool
 
     run_fractal_task(
         task_function=scmultiplex_measurements,

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -53,20 +53,40 @@ def scmultiplex_measurements(
     metadata: Dict[str, Any],
     # Task-specific arguments:
     input_ROI_table: str = "FOV_ROI_table",
-    input_channels: Dict[str, Dict[str, str]],
+    input_channels: Dict[str, Dict[str, str]] = {},
     label_image: str,
     output_table_name: str,
-    level=0,
+    level: int = 0,
+    label_level: int = 0,
     measure_morphology: bool = True,
     allow_duplicate_labels: bool = False,
 ):
     """
-    Wrapper task for scmultiplex measurements for Fractal
+    Wrapper task for scmultiplex measurements for Fractal to generate
+    measurements of intensities and morphologies
 
     :param input_paths: TBD (default arg for Fractal tasks)
     :param output_path: TBD (default arg for Fractal tasks)
     :param metadata: TBD (default arg for Fractal tasks)
     :param component: TBD (default arg for Fractal tasks)
+    :param input_ROI_table: Name of the ROI table to loop over. Needs to exists
+                            as a ROI table in the OME-Zarr file
+    :param input_channels: Dictionary of channels to measure. Keys are the
+                           names that will be added as prefixes to the
+                           measurements, values are another dictionary
+                           containing either wavelength_id or channel_label
+                           information to allow Fractal to find the correct
+                           channel (but not both). Example:
+                            {"C01": {"wavelength_id": "A01_C01"}
+                            To only measure morphology, provide an empty dict
+    :param label_image: Name of the label image to use for measurements.
+                        Needs to exist in OME-Zarr file
+    :param output_table_name: Name of the output AnnData table to save the
+                              measurements in. A table of this name can't exist
+                              yet in the OME-Zarr file
+    :param level: Resolution of the intensity image to load for measurements.
+                  Only tested for level 0
+    : param measure_morphology: Set to True to measure morphology features
     :param allow_duplicate_labels: Set to True to allow saving measurement
                                    tables with non-unique label values. Can
                                    happen when segmentation is run on a
@@ -114,10 +134,6 @@ def scmultiplex_measurements(
             "level are not currently supported"
         )
 
-    # FIXME: More reliable way to get the correct scale?
-    # Would not work well with multiple different coordinateTransformations
-    spacing = multiscales[0]["datasets"][level]["coordinateTransformations"][0]["scale"]
-
     # Read ROI table
     ROI_table = ad.read_zarr(f"{in_path}/{component}/tables/{input_ROI_table}")
 
@@ -159,26 +175,39 @@ def scmultiplex_measurements(
         logger.info(f"{input_image_arrays=}")
 
     # Set target_shape for upscaling labels
-    if not input_image_arrays:
-        # TODO: Allow user to just make morphology measurements?
-        raise ValueError(f"No images loaded for {input_channels=}")
+    # if not input_image_arrays:
+    #     # TODO: Allow user to just make morphology measurements?
+    #     raise ValueError(f"No images loaded for {input_channels=}")
 
     # FIXME: Add check whether label exists?
     input_label_image = da.from_zarr(
-        f"{in_path}/{component}/labels/{label_image}/{level}"
+        f"{in_path}/{component}/labels/{label_image}/{label_level}"
     )
 
-    # If we allow shape measurements without intensity images,
-    # then need to upscale differently
-    target_shape = list(input_image_arrays.values())[0].shape
-    input_label_image = upscale_array(
-        array=input_label_image,
-        target_shape=target_shape,
-        axis=[1, 2],
-        pad_with_zeros=True,
-    )
+    if input_channels:
+        # Upsample the label image to match the intensity image
+        target_shape = list(input_image_arrays.values())[0].shape
+        input_label_image = upscale_array(
+            array=input_label_image,
+            target_shape=target_shape,
+            axis=[1, 2],
+            pad_with_zeros=True,
+        )
+        # FIXME: More reliable way to get the correct scale? => switch to ome-zarr-py?
+        # Would not work well with multiple different coordinateTransformations
+        spacing = multiscales[0]["datasets"][level]["coordinateTransformations"][0]["scale"]
+        logger.info(f"Loaded {label_image=} and {params=}")
+    else:
+        logger.info(
+            "No intensity images provided, only calculating measurement for "
+            f"the label image {label_image}"
+            )
+        zattrs_file_label = f"{in_path}/{component}/labels/{label_image}/.zattrs"
+        with open(zattrs_file_label, "r") as jsonfile:
+            zattrs_label = json.load(jsonfile)
+        spacing = zattrs_label["multiscales"][0]["datasets"][level]["coordinateTransformations"][0]["scale"]
 
-    logger.info(f"Loaded {label_image=} and {params=}")
+    
 
     #####
 
@@ -191,61 +220,94 @@ def scmultiplex_measurements(
         logger.info(f"ROI {i_ROI+1}/{num_ROIs}: {region=}")
 
         # Load the label image
+        # TODO: Add option to mask with a ROI label mask. Actually only
+        # needs input masking here, as the return value is a table
         label_img = input_label_image[region].compute()
         if label_img.shape[0] == 1:
             logger.info("Label image is 2D only, processing with 2D options")
             label_img = np.squeeze(label_img, axis=0)
+            real_spacing = spacing[1:]
+            is_2D = True
+        elif len(label_img.shape) == 2:
+            is_2D = True
+            real_spacing = spacing
+        elif len(label_img.shape) == 3:
+            is_2D = False
+            real_spacing = spacing
+        else:
+            raise NotImplementedError(
+                f"Loaded an image of shape {label_img.shape}. "
+                "Processing is only supported for 2D & 3D images"
+            )
+        
+        # Define some constant values to be added as a separat column to
+        # the obs table
+        # TODO: Add ROI label once we allow for masked ROIs
+        extra_values = {
+            "ROI_table_name": input_ROI_table,
+            "ROI_name": ROI_table.obs.index[i_ROI],
+        }
 
         # Set inputs
         df_roi = pd.DataFrame()
         df_info_roi = pd.DataFrame()
         first_channel = True
-        for input_name in input_channels.keys():
-            img = input_image_arrays[input_name][region].compute()
-            # TODO: Add option to mask with a ROI label mask. Actually only
-            # needs input masking here, as the return value is a table
+        if input_channels:
+            for input_name in input_channels.keys():
+                img = input_image_arrays[input_name][region].compute()
+                # TODO: Add option to mask with a ROI label mask. Actually only
+                # needs input masking here, as the return value is a table
 
-            # Check whether the input is 2D or 3D
-            if img.shape[0] == 1:
-                logger.info("Image is 2D only, processing with 2D options")
-                img = np.squeeze(img, axis=0)
-                real_spacing = spacing[1:]
-                is_2D = True
-            elif len(img.shape) == 2:
-                real_spacing = spacing
-                is_2D = True
-            elif len(img.shape) == 3:
-                real_spacing = spacing
-                is_2D = False
-            else:
-                raise NotImplementedError(
-                    f"Loaded an image of shape {img.shape}. "
-                    "Processing is only supported for 2D & 3D images"
+                # Check whether the input is 2D or 3D & matches the label_img
+                if img.shape[0] == 1 and is_2D:
+                    img = np.squeeze(img, axis=0)
+                elif len(img.shape) == 2 and is_2D:
+                    pass
+                elif len(img.shape) == 3 and not is_2D:
+                    pass
+                else:
+                    raise NotImplementedError(
+                        f"Loaded an image of shape {img.shape}. "
+                        f"and label image of shape {label_img.shape}."
+                        "Processing is only supported for 2D & 3D images"
+                        "and where the label image and the input image have"
+                        "the same dimensionality."
+                    )
+
+                calc_morphology = first_channel and measure_morphology
+                new_df, new_info_df = get_regionprops_measurements(
+                    label_img,
+                    img,
+                    spacing=real_spacing,
+                    is_2D=is_2D,
+                    measure_morphology=calc_morphology,
+                    channel_prefix=input_name,
+                    extra_values=extra_values,
                 )
 
-            # Define some constant values to be added as a separat column to
-            # the obs table
-            # TODO: Add ROI label once we allow for masked ROIs
-            extra_values = {
-                "ROI_table_name": input_ROI_table,
-                "ROI_name": ROI_table.obs.index[i_ROI],
-            }
+                # Only measure morphology for the first intensity channel provided
+                # => just once per label image
+                first_channel = False
 
+                if "label" in df_roi.columns:
+                    df_roi = df_roi.merge(right=new_df, how="outer", on="label")
+                    df_info_roi = df_info_roi.merge(
+                        right=new_info_df, how="outer", on="label"
+                    )
+                else:
+                    df_roi = pd.concat([df_roi, new_df], axis=1)
+                    df_info_roi = pd.concat([df_info_roi, new_info_df], axis=1)
+        else:
+            # Only measure morphology
             calc_morphology = first_channel and measure_morphology
             new_df, new_info_df = get_regionprops_measurements(
                 label_img,
-                img,
+                img = None,
                 spacing=real_spacing,
                 is_2D=is_2D,
                 measure_morphology=calc_morphology,
-                channel_prefix=input_name,
                 extra_values=extra_values,
-            )
-
-            # Only measure morphology for the first intensity channel provided 
-            # => just once per label image
-            first_channel = False
-
+            )    
             if "label" in df_roi.columns:
                 df_roi = df_roi.merge(right=new_df, how="outer", on="label")
                 df_info_roi = df_info_roi.merge(
@@ -264,12 +326,13 @@ def scmultiplex_measurements(
     # Ensure that the label column in df_well & df_info_well match
     if not (df_well["label"] == df_info_well["label"]).all():
         raise ValueError(
-            f"Label column in df_well and df_info_well do not match. {df_well['label']} != {df_info_well['label']}"
+            "Label column in df_well and df_info_well do not match. "
+            f"{df_well['label']} != {df_info_well['label']}"
         )
 
     # Check that labels are unique
-    # Typical issue: Ran segmentation per well, but measurement per FOV 
-    # => splits labels into multiple measurements 
+    # Typical issue: Ran segmentation per well, but measurement per FOV
+    # => splits labels into multiple measurements
     if not allow_duplicate_labels:
         total_measurements = len(df_well["label"])
         unique_labels = len(df_well["label"].unique())

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -202,8 +202,7 @@ def scmultiplex_measurements(
             zattrs_label = json.load(jsonfile)
         spacing = zattrs_label["multiscales"][0]["datasets"][level]["coordinateTransformations"][0]["scale"]
 
-    #####
-
+    ##### Loop over ROIs to make measurements #####
     df_well = pd.DataFrame()
     df_info_well = pd.DataFrame()
     for i_ROI, indices in enumerate(list_indices):
@@ -339,9 +338,9 @@ def scmultiplex_measurements(
     # Convert all to float (warning: some would be int, in principle)
     measurement_dtype = np.float32
     df_well = df_well.astype(measurement_dtype)
+    df_well.index = df_well.index.map(str)
     # Convert to anndata
     measurement_table = ad.AnnData(df_well, dtype=measurement_dtype)
-    # measurement_table.obs = labels
     measurement_table.obs = df_info_well
 
     # Write to zarr group

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -86,7 +86,8 @@ def scmultiplex_measurements(
                               yet in the OME-Zarr file
     :param level: Resolution of the intensity image to load for measurements.
                   Only tested for level 0
-    : param measure_morphology: Set to True to measure morphology features
+    :param label_level: Resolution of the label image to load for measurements.
+    :param measure_morphology: Set to True to measure morphology features
     :param allow_duplicate_labels: Set to True to allow saving measurement
                                    tables with non-unique label values. Can
                                    happen when segmentation is run on a
@@ -96,10 +97,11 @@ def scmultiplex_measurements(
 
     # Level-related constraint
     logger.info(f"This workflow acts at {level=}")
-    if level != 0:
+    if level != 0 or label_level != 0:
         # TODO: Test whether this constraint can be lifted
-        raise NotImplementedError(
-            "scMultipleX Measurements are only implemented for level 0"
+        logger.warning(
+            f"Measuring at {level=} & {label_level=}: It's not recommended "
+            "to measure at lower resolutions"
         )
 
     # Pre-processing of task inputs

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -174,11 +174,6 @@ def scmultiplex_measurements(
         logger.info(f"Prepared input with {name=} and {params=}")
         logger.info(f"{input_image_arrays=}")
 
-    # Set target_shape for upscaling labels
-    # if not input_image_arrays:
-    #     # TODO: Allow user to just make morphology measurements?
-    #     raise ValueError(f"No images loaded for {input_channels=}")
-
     # FIXME: Add check whether label exists?
     input_label_image = da.from_zarr(
         f"{in_path}/{component}/labels/{label_image}/{label_level}"
@@ -206,8 +201,6 @@ def scmultiplex_measurements(
         with open(zattrs_file_label, "r") as jsonfile:
             zattrs_label = json.load(jsonfile)
         spacing = zattrs_label["multiscales"][0]["datasets"][level]["coordinateTransformations"][0]["scale"]
-
-    
 
     #####
 

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -312,9 +312,6 @@ def scmultiplex_measurements(
         df_well = pd.concat([df_well, df_roi], axis=0, ignore_index=True)
         df_info_well = pd.concat([df_info_well, df_info_roi], axis=0, ignore_index=True)
 
-    print(df_well)
-    print(list(df_well.columns))
-
     # Ensure that the label column in df_well & df_info_well match
     if not (df_well["label"] == df_info_well["label"]).all():
         raise ValueError(
@@ -365,6 +362,7 @@ if __name__ == "__main__":
         label_image: str
         output_table_name: str
         level: int
+        label_level: int
         measure_morphology: bool
 
     run_fractal_task(

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -360,13 +360,13 @@ if __name__ == "__main__":
         metadata: Dict[str, Any]
         component: str
         input_ROI_table: Optional[str]
-        input_channels: Dict[str, Dict[str, str]]
+        input_channels: Optional[Dict[str, Dict[str, str]]]
         label_image: str
         output_table_name: str
-        level: int
-        label_level: int
-        measure_morphology: bool
-        allow_duplicate_labels: bool
+        level: Optional[int]
+        label_level: Optional[int]
+        measure_morphology: Optional[bool]
+        allow_duplicate_labels: Optional[bool]
 
     run_fractal_task(
         task_function=scmultiplex_measurements,


### PR DESCRIPTION
I was anyway working on integrating the feature_wrapper function better into the Fractal task, so I also did a small refactor to address https://github.com/fmi-basel/gliberal-scMultipleX/issues/59.

The new `get_regionprops_measurements` is simplified and calls 3 helper functions for the main measurements. In my tests, it still performs the same as before (except the `C01.x_pos_weighted_pix` etc. measurement being quite different, but that was an intentional bug fix, right?

Fractal testing is still ongoing, but this can already be merged now to avoid to many different branches in parallel.