### PR TITLE
Fractal task installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,5 +48,9 @@ package_dir =
 setup_requires =
     setuptools-scm
 
+[options.extras_require]
+Fractal = 
+    fractal-tasks-core >=0.9.4
+
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ setup_requires =
 scmultiplex = __FRACTAL_MANIFEST__.json
 
 [options.extras_require]
-Fractal = 
+fractal = 
     fractal-tasks-core >=0.9.4
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,9 @@ package_dir =
 setup_requires =
     setuptools-scm
 
+[options.package_data]
+scmultiplex = __FRACTAL_MANIFEST__.json
+
 [options.extras_require]
 Fractal = 
     fractal-tasks-core >=0.9.4

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -13,7 +13,6 @@
         "measure_morphology": true
       },
       "meta": {
-        "executor": "cpu-low",
         "cpus_per_task": 1,
         "mem": 2000,
         "parallelization_level": "image"

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -3,7 +3,7 @@
   "task_list": [
     {
       "name": "scMultipleX Measurements",
-      "executable": "scmultiplex_feature_measurements.py",
+      "executable": "fractal/scmultiplex_feature_measurements.py",
       "input_type": "zarr",
       "output_type": "zarr",
       "default_args": {

--- a/src/scmultiplex/fractal/README.md
+++ b/src/scmultiplex/fractal/README.md
@@ -35,6 +35,8 @@ Afterwards, the wheel can be built using `python -m build` and collected by Frac
 fractal task collect /path/to/scmultiplex-version-details.whl --package-extras fractal
 ```
 
+(you may need to `pip install build` to run the wheel creation)
+
 **Working with a Fractal task in development**
 The above instructions work well to install the Fractal task as it is available in the package. If you want to run a task through Fractal server that you keep changing, it's not advisable to use the fractal task collection, but instead manually register your task.
 

--- a/src/scmultiplex/fractal/README.md
+++ b/src/scmultiplex/fractal/README.md
@@ -1,0 +1,39 @@
+# Using scMultipleX Fractal task
+
+Fractal comes with extra dependencies. We're currently working on separating the helper functions into its own library, so that one doesn't need to depend on the full fractal-tasks-core package. In the meantime, the extra dependencies are optional. Thus, to install them, one needs to specify them:
+```
+cd scmultiplex
+pip install ".[fracta]"
+```
+
+Or, once this package is on pypi:
+```
+pip install "scmultiplex[fracta]"
+```
+
+To collect the task in Fractal, one can load the Python wheel (see instructions below):
+```
+fractal task collect /path/to/scmultiplex-version-details.whl --package-extras fractal
+```
+
+After that, it's available in Fractal as "scMultipleX Measurements".
+
+### Developer info
+To create a new Fractal task, one needs to create a linux executable (e.g. a Python file with a `if __name__ == "__main__":` section) and this executable needs to follow the Fractal standards on how to read in inputs & store outputs ([see details here](https://fractal-analytics-platform.github.io/fractal-tasks-core/task_howto.html)). A typical Fractal task uses pydantic for input validation.
+
+To make the task installable by a Fractal server, there needs to be a `__FRACTAL_MANIFEST__.json` file in the src/scmultiplex folder. This file contains a list of all available tasks, their default parameters as well as the relative path to the executable.
+
+The manifest needs to be included when a package is built. 
+
+For local creation of a Python whl, it means that the setup.cfg contains the following:
+```
+[options.package_data]
+scmultiplex = __FRACTAL_MANIFEST__.json
+```
+Afterwards, the wheel can be built using `python -m build` and collected by Fractal using the command line client:
+```
+fractal task collect /path/to/scmultiplex-version-details.whl --package-extras fractal
+```
+
+
+

--- a/src/scmultiplex/fractal/README.md
+++ b/src/scmultiplex/fractal/README.md
@@ -35,6 +35,8 @@ Afterwards, the wheel can be built using `python -m build` and collected by Frac
 fractal task collect /path/to/scmultiplex-version-details.whl --package-extras fractal
 ```
 
+The installation of optional dependencies with fractal task collection doesn't appear to work yet with this command, even though it should. We'll work on this bug. In the meantime, one needs to manually activate the newly created task environment and `pip install fractal-tasks-core`.
+
 **Working with a Fractal task in development**
 The above instructions work well to install the Fractal task as it is available in the package. If you want to run a task through Fractal server that you keep changing, it's not advisable to use the fractal task collection, but instead manually register your task.
 

--- a/src/scmultiplex/fractal/README.md
+++ b/src/scmultiplex/fractal/README.md
@@ -35,5 +35,7 @@ Afterwards, the wheel can be built using `python -m build` and collected by Frac
 fractal task collect /path/to/scmultiplex-version-details.whl --package-extras fractal
 ```
 
+**Working with a Fractal task in development**
+The above instructions work well to install the Fractal task as it is available in the package. If you want to run a task through Fractal server that you keep changing, it's not advisable to use the fractal task collection, but instead manually register your task.
 
-
+For that purpose, create a Python environment that the task runs in (with all dependencies installed) and then use manual task registration pointing to the task Python file that you're working with. [See here for an example](https://github.com/fractal-analytics-platform/fractal-demos/tree/d241c7e29e5016bca6e0fd7647f44947e1501509/examples/08_scMultipleX_task).

--- a/src/scmultiplex/fractal/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/fractal/__FRACTAL_MANIFEST__.json
@@ -1,0 +1,23 @@
+{
+  "manifest_version": 1,
+  "task_list": [
+    {
+      "name": "scMultipleX Measurements",
+      "executable": "scmultiplex_feature_measurements.py",
+      "input_type": "zarr",
+      "output_type": "zarr",
+      "default_args": {
+        "input_ROI_table": "well_ROI_table",
+        "level": 0,
+        "label_level": 0,
+        "measure_morphology": true
+      },
+      "meta": {
+        "executor": "cpu-low",
+        "cpus_per_task": 1,
+        "mem": 2000,
+        "parallelization_level": "image"
+    }
+    }
+  ]
+}


### PR DESCRIPTION
Adding an optional fractal dependency (that installs the fractal-tasks-core package, which is currently needed for fractal tasks to work), a fractal manifest JSON and an updated Fractal readme with installation instructions.

Automated task collection doesn't work yet in Fractal for this package, but that's a bug in task collection with optional dependencies. This is ready to be merged from my side.