### PR TITLE
Add config parameters to accomodate user-specified folder naming

### DIFF
--- a/scripts/configs/config.ini.example
+++ b/scripts/configs/config.ini.example
@@ -1,6 +1,6 @@
 [00BuildExperiment]
 well_pattern = _[A-Z]{1}[0-9]{2}_
-raw_ch_pattern = C[0-9]{2}O.*_TIF-OVR.tif
+raw_ch_pattern = C[0-9]{2}O.*_ILC-OVR.tif
 mask_ending = MASK
 base_dir_raw = /path/to/gliberal-scMultipleX/resources/scMultipleX_testdata
 base_dir_save = /path/to/scmultiplex
@@ -11,10 +11,12 @@ round_names = R0,R1
 
 [00BuildExperiment.round_R0]
 name = R0
-nuc_ending = NUC_SEG3D_220523
-mem_ending = MEM_SEG3D_220523
-root_dir = ${00BuildExperiment:base_dir_raw}/testing_R0_multi
-fname_barcode_index = 2
+nuc_ending = NUC_SEG3D_azurite
+mem_ending = MEM_SEG3D
+mip_ovr_name = ILC_OVR_MIP
+org_seg_name = obj_v0.3
+root_dir = ${00BuildExperiment:base_dir_raw}/R0
+fname_barcode_index = 3
 organoid_seg_channel = C01
 nuclear_seg_channel = C01
 membrane_seg_channel = C04
@@ -23,15 +25,18 @@ membrane_seg_channel = C04
 name = R1
 nuc_ending = ${00BuildExperiment.round_R0:nuc_ending}
 mem_ending = ${00BuildExperiment.round_R0:mem_ending}
-root_dir = ${00BuildExperiment:base_dir_raw}/testing_R1_multi
-fname_barcode_index = 3
+mip_ovr_name = ${00BuildExperiment.round_R0:mip_ovr_name}
+org_seg_name = ${00BuildExperiment.round_R0:org_seg_name}
+root_dir = ${00BuildExperiment:base_dir_raw}/R1
+fname_barcode_index = ${00BuildExperiment.round_R0:fname_barcode_index}
 organoid_seg_channel = ${00BuildExperiment.round_R0:organoid_seg_channel}
 nuclear_seg_channel = ${00BuildExperiment.round_R0:nuclear_seg_channel}
 membrane_seg_channel = ${00BuildExperiment.round_R0:membrane_seg_channel}
 
+
 [01FeatureExtraction]
 excluded_plates = day2
-excluded_wells = C02
+excluded_wells = A03
 iop_cutoff = 0.6
 measure_morphology = True
 

--- a/scripts/prefect/00_build_experiment.py
+++ b/scripts/prefect/00_build_experiment.py
@@ -58,6 +58,8 @@ def create_experiment_task(
     mask_regex,
     nuc_seg_regex,
     cell_seg_regex,
+    mip_ovr_name,
+    org_seg_name,
 ):
     create_experiment(
         name=name,
@@ -71,6 +73,8 @@ def create_experiment_task(
         mask_regex=mask_regex,
         nuc_seg_regex=nuc_seg_regex,
         cell_seg_regex=cell_seg_regex,
+        mip_ovr_name=mip_ovr_name,
+        org_seg_name=org_seg_name,
         logger=get_scmultiplex_logger(),
     )
 
@@ -86,6 +90,8 @@ def run_flow(r_params, cpus):
         mask_ending = Parameter("mask_ending")
         nuc_ending = Parameter("nuc_ending")
         mem_ending = Parameter("mem_ending")
+        mip_ovr_name = Parameter("mip_ovr_name")
+        org_seg_name = Parameter("org_seg_name")
 
         name = Parameter("name")
         root_dir = Parameter("root_dir")
@@ -107,6 +113,8 @@ def run_flow(r_params, cpus):
             name=name,
             root_dir=root_dir,
             save_dir=save_dir,
+            mip_ovr_name=mip_ovr_name,
+            org_seg_name=org_seg_name,
             overview_spacing=overview_spacing,
             spacing=spacing,
             fname_barcode_index=fname_barcode_index,
@@ -156,6 +164,8 @@ def get_config_params(config_file_path):
             'name':                 ('00BuildExperiment.round_%s' % ro, 'name'),
             'nuc_ending':           ('00BuildExperiment.round_%s' % ro, 'nuc_ending'),
             'mem_ending':           ('00BuildExperiment.round_%s' % ro, 'mem_ending'),
+            'mip_ovr_name':         ('00BuildExperiment.round_%s' % ro, 'mip_ovr_name'),
+            'org_seg_name':         ('00BuildExperiment.round_%s' % ro, 'org_seg_name'),
             'root_dir':             ('00BuildExperiment.round_%s' % ro, 'root_dir'),
             }
         rp = common_params.copy()

--- a/src/scmultiplex/linking/OrganoidLinking.py
+++ b/src/scmultiplex/linking/OrganoidLinking.py
@@ -19,6 +19,7 @@ from scmultiplex.faim_hcs.records.WellRecord import WellRecord
 from skimage.io import imsave
 
 from scmultiplex.linking.OrganoidLinkingFunctions import calculate_shift, apply_shift, calculate_matching
+from scmultiplex.utils.load_utils import load_ovr
 
 
 def link_organoids(
@@ -28,6 +29,8 @@ def link_organoids(
     R0: Experiment,
     RX: Experiment,
     seg_name: str,
+    mip_ovr_name_R0: str,
+    mip_ovr_name_RX: str,
     logger=logging,
 ):
     well_id = well.well_id
@@ -38,7 +41,7 @@ def link_organoids(
         R0.get_experiment_dir(),
         well.plate.plate_id,
         well.well_id,
-        "TIF_OVR_MIP_SEG",
+        mip_ovr_name_R0 + "_SEG",
         folder_name,
     )
 
@@ -47,13 +50,14 @@ def link_organoids(
         RX.get_experiment_dir(),
         well.plate.plate_id,
         well.well_id,
-        "TIF_OVR_MIP_SEG",
+        mip_ovr_name_RX + "_SEG",
         folder_name,
     )
 
     # load overviews
     R0_ovr = well.get_segmentation(ovr_channel)[0, :, :]
     RX_ovr = RX.plates[plate_id].wells[well_id].get_segmentation(ovr_channel)[0, :, :]
+
 
     # calculate shifts
     shifts, R0_pad, RX_pad = calculate_shift(R0_ovr, RX_ovr, bin=4)

--- a/src/scmultiplex/linking/OrganoidLinking.py
+++ b/src/scmultiplex/linking/OrganoidLinking.py
@@ -55,8 +55,8 @@ def link_organoids(
     )
 
     # load overviews
-    R0_ovr = well.get_segmentation(ovr_channel)[0, :, :]
-    RX_ovr = RX.plates[plate_id].wells[well_id].get_segmentation(ovr_channel)[0, :, :]
+    R0_ovr = load_ovr(well=well, ovr_channel=ovr_channel)[0]
+    RX_ovr = load_ovr(well=RX.plates[plate_id].wells[well_id], ovr_channel=ovr_channel)[0]
 
 
     # calculate shifts

--- a/src/scmultiplex/utils/parse_utils.py
+++ b/src/scmultiplex/utils/parse_utils.py
@@ -50,6 +50,8 @@ def prepare_and_add_well(
     ovr_mips: List[str],
     overview_spacing: Tuple[float],
     well_regex: Pattern,
+    mip_ovr_name,
+    org_seg_name,
     raw_file_to_raw_name=lambda p: splitext(p)[0][-3:],
     seg_file_to_seg_name=lambda p: splitext(p)[0][-3:],
     well_path_to_well_id=lambda p: basename(p).split("_")[3],
@@ -59,7 +61,7 @@ def prepare_and_add_well(
     )
 
     seg_files = get_well_overview_segs(
-        plate=plate, well_id=well_id, well_path_to_well_id=well_path_to_well_id
+        plate=plate, well_id=well_id, well_path_to_well_id=well_path_to_well_id,mip_ovr_name=mip_ovr_name,org_seg_name=org_seg_name,
     )
     return add_well(
         plate=plate,
@@ -135,13 +137,15 @@ def get_well_overview_segs(
     plate: PlateRecord,
     well_id: str,
     well_path_to_well_id: lambda p: basename(p).split("_")[3],
+    mip_ovr_name,
+    org_seg_name,
 ):
     seg_mips = glob(
         join(
             plate.experiment.root_dir,
             plate.plate_id,
-            "TIF_OVR_MIP_SEG",
-            "obj_v0.3",
+            mip_ovr_name + "_SEG",
+            org_seg_name,
             "*.tif",
         )
     )
@@ -160,6 +164,8 @@ def create_experiment(
     mask_regex,
     nuc_seg_regex,
     cell_seg_regex,
+    mip_ovr_name,
+    org_seg_name,
     logger=logging.getLogger("HCS_Experiment"),
 ):
     def raw_file_to_raw_name(p):
@@ -184,7 +190,7 @@ def create_experiment(
                 experiment=exp, plate_id=split(p)[1], save_dir=exp.get_experiment_dir()
             )
 
-            ovr_mips = glob(join(exp.root_dir, plate.plate_id, "TIF_OVR_MIP", "*.tif"))
+            ovr_mips = glob(join(exp.root_dir, plate.plate_id, mip_ovr_name, "*.tif"))
 
             well_ids = [well_regex.findall(basename(om))[0][1:-1] for om in ovr_mips]
 
@@ -201,13 +207,15 @@ def create_experiment(
                         ovr_mips=ovr_mips,
                         overview_spacing=overview_spacing,
                         well_regex=well_regex,
+                        mip_ovr_name=mip_ovr_name,
+                        org_seg_name=org_seg_name,
                         raw_file_to_raw_name=raw_file_to_raw_name,
                         seg_file_to_seg_name=seg_file_to_seg_name,
                         well_path_to_well_id=well_path_to_well_id,
                     )
                 )
 
-            organoid_parent_dir = join(exp.root_dir, plate.plate_id, "obj_v0.3_ROI")
+            organoid_parent_dir = join(exp.root_dir, plate.plate_id, org_seg_name + "_ROI")
             if exists(organoid_parent_dir):
                 for well in wells:
                     prepare_and_add_organoids(


### PR DESCRIPTION
Removed hard-coding of TIF_OVR_MIP and obj_v0.3 folder names from Drogon output. 
This also allows scmpx to run on illumination-corrected ILC images. 