### PR TITLE
Update Task 3 to apply transformations to raw images and relabel RX segmentations

### DIFF
--- a/scripts/prefect/03_nuclear_multiplex.py
+++ b/scripts/prefect/03_nuclear_multiplex.py
@@ -32,7 +32,7 @@ from scmultiplex.config import (
     summary_csv_path,
     spacing_anisotropy_scalar,
 )
-from scmultiplex.linking.NucleiLinking import link_nuclei
+from scmultiplex.linking.NucleiLinking import apply_transform, link_nuclei
 from scmultiplex.logging import setup_prefect_handlers
 from scmultiplex.utils import get_core_count
 
@@ -67,7 +67,7 @@ def get_organoids_task(exp: Experiment, exlude_plates: List[str]):
 
 @task()
 def link_nuclei_task(organoid, segname, rx_name, RX, z_anisotropy, org_seg_ch, nuc_seg_ch):
-    link_nuclei(
+    transform_affine, organoid_R0, organoid_RX, RX_seg, RX_savepath = link_nuclei(
         organoid=organoid,
         segname=segname,
         rx_name=rx_name,
@@ -76,6 +76,10 @@ def link_nuclei_task(organoid, segname, rx_name, RX, z_anisotropy, org_seg_ch, n
         org_seg_ch=org_seg_ch,
         nuc_seg_ch=nuc_seg_ch,
     )
+
+    apply_transform(transform_affine, organoid_R0, organoid_RX, RX_seg, RX_savepath, nuc_seg_ch)
+    return
+
 
 
 def run_flow(r_params, cpus):

--- a/scripts/prefect/03_nuclear_multiplex.py
+++ b/scripts/prefect/03_nuclear_multiplex.py
@@ -84,7 +84,7 @@ def link_nuclei_task(organoid, segname, rx_name, RX, z_anisotropy, org_seg_ch, n
 
 def run_flow(r_params, cpus):
     with Flow(
-        "Nuclei-Linking", executor=LocalDaskExecutor(scheduler="processes", num_workers=cpus), run_config=LocalRun()
+        "Nuclei-Linking", executor=LocalDaskExecutor(scheduler="threads", num_workers=cpus), run_config=LocalRun()
     ) as flow:
         rx_name = Parameter("RX_name")
         r0_csv = Parameter("R0_path")

--- a/scripts/prefect/07_aggregate_nuclear_multiplex.py
+++ b/scripts/prefect/07_aggregate_nuclear_multiplex.py
@@ -43,8 +43,8 @@ def load_experiment(exp_path):
 
 @task()
 def merge_scmultiplexed_features_task(exp, round_names, round_summary_csvs):
-    merge_platymatch_linking(exp)
-    write_nuclear_linking_over_multiplexing_rounds(round_names, round_summary_csvs)
+    merge_platymatch_linking(exp, transform = "affine")
+    write_nuclear_linking_over_multiplexing_rounds(round_names, round_summary_csvs, transform = "affine")
 
 def run_flow(r_params, cpus):
     with Flow(

--- a/src/scmultiplex/linking/NucleiLinking.py
+++ b/src/scmultiplex/linking/NucleiLinking.py
@@ -81,6 +81,23 @@ def link_ffd(RX_numpy, R0_numpy, RX_raw, R0_raw, R0_seg, RX_seg, RX_obj, R0_obj,
     return ffd_matches
 
 
+def apply_transform(transform_affine, organoid_R0, organoid_RX, RX_seg, RX_savepath, nuc_seg_ch):
+
+    for channel in organoid_RX.raw_files:
+        R0_raw = organoid_R0.get_raw_data(nuc_seg_ch) # doesn't matter which channel; can load seg channel here
+        RX_raw = organoid_RX.get_raw_data(channel)
+
+        transformed_affine_raw_image = generate_affine_transformed_image(transform_affine, R0_raw, RX_raw, RX_seg)[0]
+
+        print(transformed_affine_raw_image.dtype, np.amin(transformed_affine_raw_image), np.amax(transformed_affine_raw_image))
+
+        # Save transformed RX image
+        path = join(RX_savepath, channel+"_affine_transformed.tif")
+        imsave(path, transformed_affine_raw_image.astype(np.uint16), check_contrast=False)
+
+    return transformed_affine_raw_image
+
+
 def link_nuclei(organoid, segname, rx_name, RX, z_anisotropy, org_seg_ch, nuc_seg_ch):
     """
     Run PlatyMatch linking using Prefect/FAIM-HCS data structure
@@ -210,3 +227,5 @@ def link_nuclei(organoid, segname, rx_name, RX, z_anisotropy, org_seg_ch, nuc_se
 
                     except Exception as e:
                         print(R0_obj, RX_obj, e)
+
+    return transform_affine, organoid, RX.plates[plate_id].wells[well_id].organoids[RX_obj], RX_seg, RX_savepath

--- a/src/scmultiplex/linking/NucleiLinkingFunctions.py
+++ b/src/scmultiplex/linking/NucleiLinkingFunctions.py
@@ -204,8 +204,8 @@ def run_affine(moving_pc, fixed_pc, ransac_iterations, icp_iterations):
 
     results_affine = np.column_stack(
         (
-            moving_ids[row_indices].transpose(),
             fixed_ids[col_indices].transpose(),
+            moving_ids[row_indices].transpose(),
             cost_matrix[row_indices, col_indices],
             confidence[row_indices, col_indices],
         )
@@ -296,9 +296,9 @@ def run_ffd(
 
     # Return matching ids
     results_ffd = np.column_stack(
-        (
-            moving_ffd_ids[row_indices].transpose(),
+        (   
             fixed_ids[col_indices].transpose(),
+            moving_ffd_ids[row_indices].transpose(),
             cost_matrix[row_indices, col_indices],
         )
     )

--- a/src/scmultiplex/linking/NucleiLinkingFunctions.py
+++ b/src/scmultiplex/linking/NucleiLinkingFunctions.py
@@ -332,3 +332,19 @@ def generate_ffd_rawimage_from_affine(moving_transformed_affine_raw_image,
     return moving_transformed_ffd_raw_image
 
 
+def relabel_RX_numpy(RX_seg, matches):
+    """
+    Relabel RX label map to match R0 labels based on linking. Matches is affine or ffd pandas df after platymatch matching
+    """
+    #key is moving_label, value is fixed_label
+    matching_dict = matches.set_index('RX_nuc_id').T.to_dict('index')['R0_nuc_id']
+    
+    RX_numpy_matched = np.zeros_like(RX_seg)
+
+    # for each nuclear label in RX...
+    for l in filter(None, np.unique(matches['RX_nuc_id'])):
+        # set to r0 label
+        RX_numpy_matched[RX_seg == l] = matching_dict[l]
+        
+    return RX_numpy_matched
+

--- a/src/scmultiplex/utils/accumulate_utils.py
+++ b/src/scmultiplex/utils/accumulate_utils.py
@@ -566,7 +566,7 @@ def merge_org_linking(exp: Experiment):
             )  # saves csv
 
 
-def merge_platymatch_linking(exp: Experiment):
+def merge_platymatch_linking(exp: Experiment, transform = "affine"):
     # pool together organoid linking files
     exp.only_iterate_over_wells(False)
     exp.reset_iterator()
@@ -579,7 +579,7 @@ def merge_platymatch_linking(exp: Experiment):
         linkMeasurements = [
             k
             for k, v in organoid.measurements.items()
-            if k.startswith("linking_nuc_ffd")
+            if k.startswith("linking_nuc_" + transform)
         ]
 
         # if no linking in organoid, skip
@@ -597,7 +597,7 @@ def merge_platymatch_linking(exp: Experiment):
         linkMeasurements = [
             k
             for k, v in organoid.measurements.items()
-            if k.startswith("linking_nuc_ffd")
+            if k.startswith("linking_nuc_" + transform)
         ]
 
         # if no linking in organoid, skip
@@ -616,7 +616,7 @@ def merge_platymatch_linking(exp: Experiment):
                 nuc_link_df_dict[key], ignore_index=True, sort=False
             )
             nuc_link_df.to_csv(
-                join(exp.get_experiment_dir(), ("linking_nuc_" + key + "_df.csv")),
+                join(exp.get_experiment_dir(), ("linking_nuc_" + key + "_" + transform + "_df.csv")),
                 index=False,
             )  # saves csv
 
@@ -782,7 +782,7 @@ def write_organoid_linking_over_multiplexing_rounds(round_names, round_summary_c
     )  # saves csv
 
 
-def write_nuclear_linking_over_multiplexing_rounds(round_names, round_summary_csvs):
+def write_nuclear_linking_over_multiplexing_rounds(round_names, round_summary_csvs, transform = "affine"):
     # Load the data
     exp_list = []
     df_list = []
@@ -814,7 +814,7 @@ def write_nuclear_linking_over_multiplexing_rounds(round_names, round_summary_cs
         # skip R0
         if i > 0:
             path = os.path.join(
-                exps["R0"].get_experiment_dir(), ("linking_nuc_R" + str(i) + "_df.csv")
+                exps["R0"].get_experiment_dir(), ("linking_nuc_R" + str(i) + "_" + transform + "_df.csv")
             )
             isExist = os.path.exists(path)
 
@@ -980,7 +980,7 @@ def write_nuclear_linking_over_multiplexing_rounds(round_names, round_summary_cs
     nuc_df_tidy.to_csv(
         join(
             exps["R0"].get_experiment_dir(),
-            ("nuc_df_tidy_linked_" + "-".join(round_names) + ".csv"),
+            ("nuc_df_tidy_linked_" + transform + "_" + "-".join(round_names) + ".csv"),
         ),
         index=False,
     )  # saves csv


### PR DESCRIPTION
Modifications include:

- Bug fix of output df column naming (R0 and RX was swapped)
- Option to relabel RX segmentations to R0 according to affine matching
- Option to apply affine transformation to RX raw images (all channels)
- Fix task 7 aggregation to choose affine vs. ffd tranformation for aggregation
- Switching to threading parallelization for Prefect task 3 to avoid deadlock situations