### PR TITLE
Generalize surface mesh task

### DIFF
--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -513,79 +513,78 @@
             "title": "Label Name",
             "default": "nuc",
             "type": "string",
-            "description": "Label name of child objects that will be used for multiscale surface estimation, e.g. `nuc`."
+            "description": "Label name of segmentation for which mesh is calculated. When Multiscale = True, this is the label name of child objects (e.g. nuclei) that will be used for multiscale surface estimation."
           },
-          "label_name_obj": {
-            "title": "Label Name Obj",
-            "default": "org_linked",
+          "group_by": {
+            "title": "Group By",
             "type": "string",
-            "description": "Label name of segmented objects that are parents of label_name e.g. `org`."
+            "description": "Label name of segmentated objects that are parents of label_name. If None (default), no grouping is applied and meshes are calculated for the input object (label_name). Instead, if a group_by label is specified, the label_name objects will be masked and grouped by this object. For example, when group_by = 'org', the nuclear segmentation is masked by the organoid parent and all nuclei belonging to the parent are loaded as a label image. Thus, when Multiscale = False, the calculated mesh contains multiple child objects. When Multiscale = True, a new labelmap is generated as a result of child fusion to generate the 3D parent (organoid-level) shape."
           },
           "roi_table": {
             "title": "Roi Table",
             "default": "org_ROI_table_linked",
             "type": "string",
-            "description": "Name of the ROI table that corresponds to label_name_obj. The task loops over ROIs in this table to load the corresponding child objects."
+            "description": "Name of the ROI table used to iterate over objects and load object regions. If group_by = None, this is the ROI table that corresponds to the label_name objects. If group_by is passed, this is the ROI table for the group_by objects, e.g. org_ROI_table."
+          },
+          "multiscale": {
+            "title": "Multiscale",
+            "default": true,
+            "type": "boolean",
+            "description": "if True, a new labelmap is generated as a result of child fusion to generate the 3D parent (organoid-level) shape. This label output is called {group_by}_from_{label_name}, with corresponding ROI table name {group_by}_ROI_table_from_{label_name}. This label image is optionally saved as a mesh if save_mesh = True. If Multiscale = False, no multiscale label map computation is performed and a smoothened mesh of the input label_name is generated."
+          },
+          "save_mesh": {
+            "title": "Save Mesh",
+            "default": true,
+            "type": "boolean",
+            "description": "if True, calculates and saves mesh on disk in the 'meshes' folder within zarr structure. Meshes saved as '.stl', except for the case of multi-object meshed (e.g. multiple nuclei within a parent organoid) that are saved as '.vtp' to preserve label ID information. Filename corresponds to parent object label id, or to label id in the case when group_by = None."
           },
           "expandby_factor": {
             "title": "Expandby Factor",
             "default": 0.6,
             "type": "number",
-            "description": "multiplier that specifies pixels by which to expand each nuclear mask for merging, float in range [0, 1 or higher], e.g. 0.2 means that 20% of mean of nuclear equivalent diameter is used."
+            "description": "only used if Multiscale = True. Multiplier that specifies pixels by which to expand each nuclear mask for merging, float in range [0, 1 or higher], e.g. 0.2 means that 20% of mean of nuclear equivalent diameter is used."
           },
           "sigma_factor": {
             "title": "Sigma Factor",
             "default": 5,
             "type": "number",
-            "description": "float that specifies sigma (standard deviation, in pixels) for Gaussian kernel used for blurring to smoothen label image prior to edge detection. Higher values correspond to more blurring. Recommended range 1-8."
+            "description": "only used if Multiscale = True. Float that specifies sigma (standard deviation, in pixels) for Gaussian kernel used for blurring to smoothen label image prior to edge detection. Higher values correspond to more blurring. Recommended range 5-15."
           },
           "canny_threshold": {
             "title": "Canny Threshold",
             "default": 0.3,
             "type": "number",
-            "description": "image values below this threshold are set to 0 after Gaussian blur. float in range [0,1]. Higher values result in tighter fit of mesh to nuclear surface"
-          },
-          "calculate_mesh": {
-            "title": "Calculate Mesh",
-            "default": true,
-            "type": "boolean",
-            "description": "if True, saves the mesh as .stl on disk in meshes/[labelname] folder within zarr structure. Filename corresponds to object label id"
+            "description": "only used if Multiscale = True. Image values below this threshold are set to 0 after Gaussian blur. float in range [0,1]. Higher values result in tighter fit of mesh to nuclear surface."
           },
           "polynomial_degree": {
             "title": "Polynomial Degree",
             "default": 30,
             "type": "integer",
-            "description": "the number of polynomial degrees during surface mesh smoothing with vtkWindowedSincPolyDataFilter determines the maximum number of smoothing passes. This number corresponds to the degree of the polynomial that is used to approximate the windowed sinc function. Usually 10-20 iteration are sufficient. Higher values have little effect on smoothing. For further details see VTK vtkWindowedSincPolyDataFilter documentation."
+            "description": "Mesh smoothing parameter. The number of polynomial degrees during surface mesh smoothing with vtkWindowedSincPolyDataFilter determines the maximum number of smoothing passes. This number corresponds to the degree of the polynomial that is used to approximate the windowed sinc function. Usually 10-20 iteration are sufficient. Higher values have little effect on smoothing. For further details see VTK vtkWindowedSincPolyDataFilter documentation."
           },
           "passband": {
             "title": "Passband",
             "default": 0.01,
             "type": "number",
-            "description": "float in range [0,2] that specifies the PassBand for the windowed sinc filter in vtkWindowedSincPolyDataFilter during mesh smoothing. Lower passband values produce more smoothing, due to filtering of higher frequencies. For further details see VTK vtkWindowedSincPolyDataFilter documentation."
+            "description": "Mesh smoothing parameter. Float in range [0,2] that specifies the PassBand for the windowed sinc filter in vtkWindowedSincPolyDataFilter during mesh smoothing. Lower passband values produce more smoothing, due to filtering of higher frequencies. For further details see VTK vtkWindowedSincPolyDataFilter documentation."
           },
           "feature_angle": {
             "title": "Feature Angle",
             "default": 160,
             "type": "integer",
-            "description": "int in range [0,180] that specifies the feature angle for sharp edge identification used for vtk FeatureEdgeSmoothing. Higher values result in more smoothened edges in mesh. For further details see VTK vtkWindowedSincPolyDataFilter documentation."
+            "description": "Mesh smoothing parameter. Integer in range [0,180] that specifies the feature angle for sharp edge identification used for vtk FeatureEdgeSmoothing. Higher values result in more smoothened edges in mesh. For further details see VTK vtkWindowedSincPolyDataFilter documentation."
           },
           "target_reduction": {
             "title": "Target Reduction",
             "default": 0.98,
             "type": "number",
-            "description": "float in range [0,1]. Target reduction is used during mesh decimation via vtkQuadricDecimation to reduce the number of triangles in a triangle mesh, forming a good approximation to the original geometry. Values closer to 1 indicate larger reduction and smaller mesh file size. Note that target_reduction is expressed as the fraction of the original number of triangles in mesh and so is proportional to original mesh size. Note the actual reduction may be less depending on triangulation and topological constraints. For further details see VTK vtkQuadricDecimation documentation."
+            "description": "Mesh decimation parameter. Float in range [0,1]. Target reduction is used during mesh decimation via vtkQuadricDecimation to reduce the number of triangles in a triangle mesh, forming a good approximation to the original geometry. Values closer to 1 indicate larger reduction and smaller mesh file size. Note that target_reduction is expressed as the fraction of the original number of triangles in mesh and so is proportional to original mesh size. Note the actual reduction may be less depending on triangulation and topological constraints. For further details see VTK vtkQuadricDecimation documentation."
           },
           "smoothing_iterations": {
             "title": "Smoothing Iterations",
             "default": 1,
             "type": "integer",
-            "description": "the number of iterations that mesh smoothing and decimation is run. If smoothing_iterations > 1, the decimated result is used as input for subsequent smoothing rounds. Recommended to start with 1 iteration and increase if resulting smoothing is insufficient. For each iteration after the first, the passband is reduced and feature_angle is increased incrementally to enhance smoothing. Specifically, the passband is reduced by factor 1/(2^n), and the feature_angle is increased by an increment of (5 * n), where n = iteration round (n=0 is the first iteration). The target_reduction is fixed to 0.1 smoothing_iterations > 1. For example if user inputs (0.01, 160, 0.98) for (passband, feature_angle, target_reduction), the second iteration will use parameters (0.005, 165, 0.1), the third (0.0025, 170, 0.1), etc. Maximum feature_angle is capped at 180. Note that additional iterations usually do not significantly add to processing time as the number of mesh verteces is typically significantly reduced after the first decimation iteration."
-          },
-          "save_labels": {
-            "title": "Save Labels",
-            "default": true,
-            "type": "boolean",
-            "description": "if True, saves the calculated 3D label map as label map in 'labels' with suffix '_3d'"
+            "description": " Mesh smoothing parameter. The number of iterations that mesh smoothing and decimation is run. If smoothing_iterations > 1, the decimated result is used as input for subsequent smoothing rounds. Recommended to start with 1 iteration and increase if resulting smoothing is insufficient. For each iteration after the first, the passband is reduced and feature_angle is increased incrementally to enhance smoothing. Specifically, the passband is reduced by factor 1/(2^n), and the feature_angle is increased by an increment of (5 * n), where n = iteration round (n=0 is the first iteration). The target_reduction is fixed to 0.1 smoothing_iterations > 1. For example if user inputs (0.01, 160, 0.98) for (passband, feature_angle, target_reduction), the second iteration will use parameters (0.005, 165, 0.1), the third (0.0025, 170, 0.1), etc. Maximum feature_angle is capped at 180. Note that additional iterations usually do not significantly add to processing time as the number of mesh verteces is typically significantly reduced after the first decimation iteration."
           }
         },
         "required": [

--- a/src/scmultiplex/features/FeatureFunctions.py
+++ b/src/scmultiplex/features/FeatureFunctions.py
@@ -287,9 +287,12 @@ def mesh_sphericity(volume, surface_area):
     This is a 3D version of circularity.
     """
     equivalent_sa = mesh_equivalent_surface_area(volume)
-    if equivalent_sa == 0:
-        raise ValueError('Cannot calculate sphericity for object with volume = 0')
-    return surface_area / equivalent_sa
+    try:
+        sphericity = surface_area / equivalent_sa
+    except ZeroDivisionError:
+        sphericity = 0
+
+    return sphericity
 
 
 def mesh_extent(object_volume, bbox_volume):

--- a/src/scmultiplex/features/FeatureFunctions.py
+++ b/src/scmultiplex/features/FeatureFunctions.py
@@ -268,9 +268,14 @@ def mesh_equivalent_surface_area(volume):
 
 def mesh_equivalent_diameter(volume):
     """
-    The diameter of a sphere with the same volume as the object region
+    Calculate equivalent diameter of sphere with a given volume
     """
-    equiv_diam = 2 * ((0.75 * volume * (1/math.pi)) ** (1. / 3.))
+    try:
+        equiv_diam = 2 * ((0.75 * volume * (1/math.pi)) ** (1. / 3.))
+    # ValueError is raised when input value is negative
+    # in this case set diameter to 0
+    except ValueError:
+        equiv_diam = 0
     return equiv_diam
 
 

--- a/src/scmultiplex/features/MeshExtraction.py
+++ b/src/scmultiplex/features/MeshExtraction.py
@@ -1,3 +1,11 @@
+# Copyright (C) 2024 Friedrich Miescher Institute for Biomedical Research
+
+##############################################################################
+#                                                                            #
+# Author: Nicole Repina              <nicole.repina@fmi.ch>                  #
+#                                                                            #
+##############################################################################
+
 from scmultiplex.features.FeatureFunctions import mesh_sphericity, mesh_extent, mesh_solidity, mesh_concavity, \
     mesh_asymmetry, mesh_aspect_ratio, mesh_surface_area_to_volume_norm
 from scmultiplex.meshing.MeshFunctions import get_centroid, get_mass_properties, get_bounding_box, get_convex_hull

--- a/src/scmultiplex/fractal/calculate_linking_consensus.py
+++ b/src/scmultiplex/fractal/calculate_linking_consensus.py
@@ -67,9 +67,7 @@ def calculate_linking_consensus(
     logger.info(
         f"Running for reference round {zarr_url=}. \n"
         f"Applying consensus finding to {roi_table=} and storing it as "
-        f"{consensus_table_name=} in reference round {ref_acquisition} directory. \n"
-        "Calculating consensus for the following cycles: "
-        f"{init_args.zarr_url_list}"
+        f"{consensus_table_name=} in reference round {ref_acquisition} directory."
     )
 
     # TODO: refactor to perform data merging on anndata without need to convert to pandas.
@@ -107,7 +105,8 @@ def calculate_linking_consensus(
     consensus['consensus_label'] = consensus['consensus_index']+1
 
     # Consensus table has columns ["R0_label", "R1_label", "R2_label", ... "consensus_index", 'consensus_label']
-    logger.info(consensus)
+    logger.info(f"Successfully calculated consensus labels for {len(consensus.index)} objects across round(s) "
+                f"{list(roi_tables.keys())} and reference round {ref_acquisition}.")
 
     # Convert to adata
     consensus_adata = ad.AnnData(X=np.array(consensus, dtype=np.float32))

--- a/src/scmultiplex/fractal/fractal_helper_functions.py
+++ b/src/scmultiplex/fractal/fractal_helper_functions.py
@@ -113,6 +113,17 @@ def find_consensus(*, df_list: Sequence[pd.DataFrame], on: Sequence[str]) -> pd.
     return consensus
 
 
+def check_for_duplicates(pd_column):
+    """
+    Check if input pandas df column contains duplicated entries.
+    Returns: is_duplicated, boolean; True if there are 1 or more duplicated item, otherwise False.
+    """
+    s = pd.Series(pd_column)
+    res = s.duplicated()
+    is_duplicated = any(res)
+    return is_duplicated
+
+
 def extract_acq_info(zarr_url):
     """
     Find name of acquisition (cycles, e.g. 0, 1, 2, etc) of given paths from their metadata

--- a/src/scmultiplex/fractal/fractal_helper_functions.py
+++ b/src/scmultiplex/fractal/fractal_helper_functions.py
@@ -8,13 +8,19 @@
 #
 from pathlib import Path
 import anndata as ad
+import dask.array as da
 import zarr
 import pandas as pd
 import numpy as np
+import os as os
+
+from fractal_tasks_core.labels import prepare_label_group
 from fractal_tasks_core.ngff import load_NgffWellMeta
-from fractal_tasks_core.roi import empty_bounding_box_table
+from fractal_tasks_core.roi import empty_bounding_box_table, load_region, array_to_bounding_box_table
 from functools import reduce
 from typing import Sequence
+
+from scmultiplex.meshing.MeshFunctions import labels_to_mesh, export_stl_polydata, export_vtk_polydata
 
 
 def read_table_and_attrs(zarr_url: Path, roi_table):
@@ -127,3 +133,103 @@ def extract_acq_info(zarr_url):
         raise ValueError(f"{zarr_url=} well metadata does not contain expected path and acquisition naming")
 
     return zarr_acquisition
+
+
+def initialize_new_label(zarr_url, shape, chunks, label_dtype, inherit_from_label, output_label_name, logger):
+    store = zarr.storage.FSStore(f"{zarr_url}/labels/{output_label_name}/0")
+
+    if len(shape) != 3 or len(chunks) != 3 or shape[0] == 1:
+        raise ValueError('Expecting 3D image')
+
+    # Add metadata to labels group
+    # Get the label_attrs correctly
+    # Note that the new label metadata matches the label_name (child) metadata
+    label_attrs = get_zattrs(zarr_url=f"{zarr_url}/labels/{inherit_from_label}")
+    _ = prepare_label_group(
+        image_group=zarr.group(zarr_url),
+        label_name=output_label_name,
+        overwrite=True,
+        label_attrs=label_attrs,
+        logger=logger,
+    )
+
+    new_label3d_array = zarr.create(
+        shape=shape,
+        chunks=chunks,
+        dtype=label_dtype,
+        store=store,
+        overwrite=True,
+        dimension_separator="/",
+    )
+    return new_label3d_array
+
+
+def save_new_label_with_overlap(new_npimg, label_str, new_label3d_array, zarr_url, output_label_name, region,
+                                label_pixmeta, compute, roi_idlist, row_int):
+    # Load dask from disk, will contain rois of the previously processed objects within for loop
+    new_label3d_dask = da.from_zarr(f"{zarr_url}/labels/{output_label_name}/0")
+    # Load region of current object from disk, will include any previously processed neighboring objects
+    seg_ondisk = load_region(
+        data_zyx=new_label3d_dask,
+        region=region,
+        compute=compute,
+    )
+
+    # Check that dimensions of rois match
+    if seg_ondisk.shape != new_npimg.shape:
+        raise ValueError('Computed label image must match image dimensions of bounding box during saving')
+
+    # Convert edge detection label image value to match object label id
+    new_npimg_label = new_npimg * int(label_str)
+    # Use fmax so that if one of the elements being compared is a NaN, then the non-nan element is returned
+    new_npimg_label_tosave = np.fmax(new_npimg_label, seg_ondisk)
+
+    # Compute and store 0-th level of new 3d label map to disk
+    da.array(new_npimg_label_tosave).to_zarr(
+        url=new_label3d_array,
+        region=region,
+        compute=True,
+    )
+
+    # make new ROI table
+    origin_zyx = convert_indices_to_origin_zyx(roi_idlist[row_int])
+
+    bbox_df = array_to_bounding_box_table(
+        new_npimg_label,
+        label_pixmeta,
+        origin_zyx=origin_zyx,
+    )
+
+    return bbox_df
+
+
+def compute_and_save_mesh(label_image, pixmeta, polynomial_degree, passband, feature_angle, target_reduction,
+                          smoothing_iterations, zarr_url, mesh_folder_name, object_name, save_as_stl):
+    # Make mesh with vtkDiscreteFlyingEdges3D algorithm
+    # Set spacing to ome-zarr pixel spacing metadata. Mesh will be in physical units (um)
+    spacing = tuple(np.array(pixmeta))  # z,y,x e.g. (0.6, 0.216, 0.216)
+
+    # Pad border with 0 so that the mesh forms a manifold
+    label_image_padded = np.pad(label_image, 1)
+
+    # Calculate mesh
+    mesh_polydata = labels_to_mesh(label_image_padded, spacing,
+                                   polynomial_degree=polynomial_degree,
+                                   pass_band_param=passband,
+                                   feature_angle=feature_angle,
+                                   target_reduction=target_reduction,
+                                   smoothing_iterations=smoothing_iterations,
+                                   margin=5,
+                                   show_progress=False)
+    # Save mesh
+    save_transform_path = f"{zarr_url}/meshes/{mesh_folder_name}"
+    os.makedirs(save_transform_path, exist_ok=True)
+
+    if save_as_stl is True:
+        save_name = f"{int(object_name)}.stl"  # save name is the parent label id
+        export_stl_polydata(os.path.join(save_transform_path, save_name), mesh_polydata)
+    # Otherwise save as .vtp
+    else:
+        save_name = f"{int(object_name)}.vtp"  # save name is the parent label id
+        export_vtk_polydata(os.path.join(save_transform_path, save_name), mesh_polydata)
+    return mesh_polydata

--- a/src/scmultiplex/fractal/surface_mesh_multiscale.py
+++ b/src/scmultiplex/fractal/surface_mesh_multiscale.py
@@ -38,11 +38,11 @@ from skimage.measure import label
 from skimage.morphology import disk, remove_small_objects
 from skimage.segmentation import expand_labels
 
-from scmultiplex.features.FeatureFunctions import mesh_sphericity
+from scmultiplex.features.FeatureFunctions import mesh_sphericity, mesh_equivalent_diameter
 from scmultiplex.fractal.fractal_helper_functions import get_zattrs, convert_indices_to_origin_zyx, format_roi_table
 
-from scmultiplex.meshing.FilterFunctions import equivalent_diam, mask_by_parent_object, \
-    calculate_mean_volume, load_border_values, remove_border
+from scmultiplex.meshing.FilterFunctions import (mask_by_parent_object,
+                                                 calculate_mean_volume, load_border_values, remove_border)
 from scmultiplex.meshing.MeshFunctions import labels_to_mesh, export_stl_polydata, get_mass_properties
 
 logger = logging.getLogger(__name__)
@@ -273,7 +273,7 @@ def surface_mesh_multiscale(
         seg_fill = np.zeros_like(seg)
 
         # the number of pixels by which to expand is a function of average nuclear size within the organoid.
-        expandby_pix = int(round(expandby_factor * equivalent_diam(size_mean)))
+        expandby_pix = int(round(expandby_factor * mesh_equivalent_diameter(size_mean)))
         if expandby_pix == 0:
             logger.warning("Equivalent diameter is 0 or negative, thus labels not expanded. Check segmentation quality")
 

--- a/src/scmultiplex/fractal/surface_mesh_multiscale.py
+++ b/src/scmultiplex/fractal/surface_mesh_multiscale.py
@@ -17,10 +17,8 @@ import anndata as ad
 import dask.array as da
 import logging
 import numpy as np
-import os
-
 import zarr
-from fractal_tasks_core.labels import prepare_label_group
+
 from fractal_tasks_core.pyramids import build_pyramid
 from fractal_tasks_core.tables import write_table
 from fractal_tasks_core.tasks.io_models import InitArgsRegistrationConsensus
@@ -31,14 +29,17 @@ from fractal_tasks_core.roi import (
     check_valid_ROI_indices,
     convert_indices_to_regions,
     convert_ROI_table_to_indices,
-    load_region, array_to_bounding_box_table, get_overlapping_pairs_3D)
+    load_region, get_overlapping_pairs_3D)
 
 from scmultiplex.features.FeatureFunctions import mesh_sphericity
-from scmultiplex.fractal.fractal_helper_functions import get_zattrs, convert_indices_to_origin_zyx, format_roi_table
+from scmultiplex.fractal.fractal_helper_functions import format_roi_table, \
+    compute_and_save_mesh, initialize_new_label, save_new_label_with_overlap
 
 from scmultiplex.meshing.FilterFunctions import mask_by_parent_object
 from scmultiplex.meshing.LabelFusionFunctions import run_label_fusion
-from scmultiplex.meshing.MeshFunctions import labels_to_mesh, export_stl_polydata, get_mass_properties
+from scmultiplex.meshing.MeshFunctions import get_mass_properties
+
+from typing import Union
 
 logger = logging.getLogger(__name__)
 
@@ -51,18 +52,18 @@ def surface_mesh_multiscale(
         init_args: InitArgsRegistrationConsensus,
         # Task-specific arguments
         label_name: str = "nuc",
-        label_name_obj: str = "org_linked",
+        group_by: Union[str, None] = None,
         roi_table: str = "org_ROI_table_linked",
+        multiscale: bool = True,
+        save_mesh: bool = True,
         expandby_factor: float = 0.6,
         sigma_factor: float = 5,
         canny_threshold: float = 0.3,
-        calculate_mesh: bool = True,
         polynomial_degree: int = 30,
         passband: float = 0.01,
         feature_angle: int = 160,
         target_reduction: float = 0.98,
         smoothing_iterations: int = 1,
-        save_labels: bool = True,
 
 ) -> dict[str, Any]:
     """
@@ -95,38 +96,57 @@ def surface_mesh_multiscale(
             zarr_url_list listing all the zarr_urls in the same well as the
             zarr_url of the reference acquisition that are being processed.
             (standard argument for Fractal tasks, managed by Fractal server).
-        label_name: Label name of child objects that will be used for multiscale surface estimation, e.g. `nuc`.
-        label_name_obj: Label name of segmented objects that are parents of
-            label_name e.g. `org`.
-        roi_table: Name of the ROI table that corresponds to label_name_obj. The task loops over ROIs in this table
-            to load the corresponding child objects.
-        expandby_factor: multiplier that specifies pixels by which to expand each nuclear mask for merging,
-            float in range [0, 1 or higher], e.g. 0.2 means that 20% of mean of nuclear equivalent diameter is used.
-        sigma_factor: float that specifies sigma (standard deviation, in pixels) for Gaussian kernel used for blurring
-            to smoothen label image prior to edge detection. Higher values correspond to more blurring.
-            Recommended range 1-8.
-        canny_threshold: image values below this threshold are set to 0 after Gaussian blur. float in range [0,1].
-            Higher values result in tighter fit of mesh to nuclear surface
-        calculate_mesh: if True, saves the mesh as .stl on disk in meshes/[labelname] folder within zarr structure.
-            Filename corresponds to object label id
-        polynomial_degree: the number of polynomial degrees during surface mesh smoothing with
+        label_name: Label name of segmentation for which mesh is calculated. When Multiscale = True, this is the label
+            name of child objects (e.g. nuclei) that will be used for multiscale surface estimation.
+        group_by: Label name of segmentated objects that are parents of label_name. If None (default), no grouping
+            is applied and meshes are calculated for the input object (label_name).
+            Instead, if a group_by label is specified, the
+            label_name objects will be masked and grouped by this object. For example, when group_by = 'org', the
+            nuclear segmentation is masked by the organoid parent and all nuclei belonging to the parent are loaded
+            as a label image. Thus, when Multiscale = False, the calculated mesh contains multiple child objects. When
+            Multiscale = True, a new labelmap is generated as a result of child fusion to generate the
+            3D parent (organoid-level) shape.
+        roi_table: Name of the ROI table used to iterate over objects and load object regions. If group_by = None, this
+            is the ROI table that corresponds to the label_name objects. If group_by is passed, this is the ROI table
+            for the group_by objects, e.g. org_ROI_table.
+        multiscale: if True, a new labelmap is generated as a result of child fusion to generate the
+            3D parent (organoid-level) shape. This label output is called {group_by}_from_{label_name},
+            with corresponding ROI table name {group_by}_ROI_table_from_{label_name}. This label image is
+            optionally saved as a mesh if save_mesh = True. If Multiscale = False, no multiscale label map computation
+            is performed and a smoothened mesh of the input label_name is generated.
+        save_mesh: if True, calculates and saves mesh on disk in the 'meshes' folder within zarr structure. Meshes
+            saved as '.stl', except for the case of multi-object meshed (e.g. multiple nuclei within a parent organoid)
+            that are saved as '.vtp' to preserve label ID information. Filename corresponds to parent object label id,
+            or to label id in the case when group_by = None.
+        expandby_factor: only used if Multiscale = True. Multiplier that specifies pixels by which to expand each
+            nuclear mask for merging, float in range [0, 1 or higher], e.g. 0.2 means that 20% of mean of
+            nuclear equivalent diameter is used.
+        sigma_factor: only used if Multiscale = True. Float that specifies sigma (standard deviation, in pixels)
+            for Gaussian kernel used for blurring to smoothen label image prior to edge detection.
+            Higher values correspond to more blurring. Recommended range 5-15.
+        canny_threshold: only used if Multiscale = True. Image values below this threshold are set to 0 after
+            Gaussian blur. float in range [0,1]. Higher values result in tighter fit of mesh to nuclear surface.
+        polynomial_degree: Mesh smoothing parameter. The number of polynomial degrees during surface mesh smoothing with
             vtkWindowedSincPolyDataFilter determines the maximum number of smoothing passes.
             This number corresponds to the degree of the polynomial that is used to approximate the windowed sinc
             function. Usually 10-20 iteration are sufficient. Higher values have little effect on smoothing.
             For further details see VTK vtkWindowedSincPolyDataFilter documentation.
-        passband: float in range [0,2] that specifies the PassBand for the windowed sinc filter in
-            vtkWindowedSincPolyDataFilter during mesh smoothing. Lower passband values produce more smoothing, due to
-            filtering of higher frequencies. For further details see VTK vtkWindowedSincPolyDataFilter documentation.
-        feature_angle: int in range [0,180] that specifies the feature angle for sharp edge identification used
-            for vtk FeatureEdgeSmoothing. Higher values result in more smoothened edges in mesh.
-            For further details see VTK vtkWindowedSincPolyDataFilter documentation.
-        target_reduction: float in range [0,1]. Target reduction is used during mesh decimation via
+        passband: Mesh smoothing parameter. Float in range [0,2] that specifies the PassBand for the windowed sinc
+            filter in vtkWindowedSincPolyDataFilter during mesh smoothing. Lower passband values produce more
+            smoothing, due to filtering of higher frequencies. For further details see
+            VTK vtkWindowedSincPolyDataFilter documentation.
+        feature_angle: Mesh smoothing parameter. Integer in range [0,180] that specifies the feature angle for sharp
+            edge identification used for vtk FeatureEdgeSmoothing. Higher values result in more smoothened
+            edges in mesh. For further details see VTK vtkWindowedSincPolyDataFilter documentation.
+        target_reduction: Mesh decimation parameter. Float in range [0,1].
+            Target reduction is used during mesh decimation via
             vtkQuadricDecimation to reduce the number of triangles in a triangle mesh, forming a good approximation to
             the original geometry. Values closer to 1 indicate larger reduction and smaller mesh file size. Note that
             target_reduction is expressed as the fraction of the original number of triangles in mesh and so is
             proportional to original mesh size. Note the actual reduction may be less depending on triangulation and
             topological constraints. For further details see VTK vtkQuadricDecimation documentation.
-        smoothing_iterations: the number of iterations that mesh smoothing and decimation is run.
+        smoothing_iterations:  Mesh smoothing parameter.
+            The number of iterations that mesh smoothing and decimation is run.
             If smoothing_iterations > 1, the decimated result is used as input for subsequent smoothing rounds.
             Recommended to start with 1 iteration and increase if resulting smoothing is insufficient. For each
             iteration after the first, the passband is reduced and feature_angle is increased incrementally to
@@ -137,7 +157,7 @@ def surface_mesh_multiscale(
             iteration will use parameters (0.005, 165, 0.1), the third (0.0025, 170, 0.1), etc. Maximum feature_angle
             is capped at 180. Note that additional iterations usually do not significantly add to processing time as
             the number of mesh verteces is typically significantly reduced after the first decimation iteration.
-        save_labels: if True, saves the calculated 3D label map as label map in 'labels' with suffix '_3d'
+
 
     """
     logger.info(
@@ -146,68 +166,55 @@ def surface_mesh_multiscale(
         f"{label_name=}."
     )
 
+    if multiscale is True and group_by is None:
+        raise ValueError(f"Multiscale calculation is not possible without a provided group_by label for parent objects."
+                         f" Check task inputs.")
+
+    if group_by in ["", " ", "   ",]:
+        raise ValueError(f"Input group_by label name is not valid. Check task inputs.")
+
     # always use highest resolution label
     level = 0
 
     # Lazily load zarr array for reference cycle
     # load well image as dask array e.g. for nuclear segmentation
-    r0_dask = da.from_zarr(f"{zarr_url}/labels/{label_name}/{level}")
+    label_dask = da.from_zarr(f"{zarr_url}/labels/{label_name}/{level}")
 
     # Read ROIs of objects
-    r0_adata = ad.read_zarr(f"{zarr_url}/tables/{roi_table}")
+    roi_adata = ad.read_zarr(f"{zarr_url}/tables/{roi_table}")
 
     # Read Zarr metadata
-    r0_ngffmeta = load_NgffImageMeta(f"{zarr_url}/labels/{label_name}")
-    r0_xycoars = r0_ngffmeta.coarsening_xy  # need to know when building new pyramids
-    r0_pixmeta = r0_ngffmeta.get_pixel_sizes_zyx(level=level)
+    label_ngffmeta = load_NgffImageMeta(f"{zarr_url}/labels/{label_name}")
+    label_xycoars = label_ngffmeta.coarsening_xy  # need to know when building new pyramids
+    label_pixmeta = label_ngffmeta.get_pixel_sizes_zyx(level=level)
 
     # Create list of indices for 3D ROIs spanning the entire Z direction
-    r0_idlist = convert_ROI_table_to_indices(
-        r0_adata,
+    # Note that this ROI list is generated based on the input ROI table; if the input ROI table is for the group_by
+    # objects, then label regions will be loaded based on the group_by ROIs
+    roi_idlist = convert_ROI_table_to_indices(
+        roi_adata,
         level=level,
-        coarsening_xy=r0_xycoars,
-        full_res_pxl_sizes_zyx=r0_pixmeta,
+        coarsening_xy=label_xycoars,
+        full_res_pxl_sizes_zyx=label_pixmeta,
     )
 
-    check_valid_ROI_indices(r0_idlist, roi_table)
+    check_valid_ROI_indices(roi_idlist, roi_table)
 
-    if len(r0_idlist) == 0:
+    if len(roi_idlist) == 0:
         logger.warning("Well contains no objects")
 
-    # initialize new zarr for 3d object label image
-    # save as same dimensions as nuclear labels from which they are calculated
-    output_label_name = label_name_obj + '_3d'
-    output_roi_table_name = roi_table + '_3d'
+    if multiscale:
+        # Initialize parameters to save the newly calculated label map
+        # Save with same dimensions as child labels from which they are calculated
 
-    if save_labels:
-        shape = r0_dask.shape
-        chunks = r0_dask.chunksize
-        label_dtype = np.uint32
-        store = zarr.storage.FSStore(f"{zarr_url}/labels/{output_label_name}/0")
+        output_label_name = f"{group_by}_from_{label_name}"
+        output_roi_table_name = f"{group_by}_ROI_table_from_{label_name}"
 
-        if len(shape) != 3 or len(chunks) != 3 or shape[0] == 1:
-            raise ValueError('Expecting 3D image')
+        shape = label_dask.shape
+        chunks = label_dask.chunksize
 
-        # Add metadata to labels group
-        # Get the label_attrs correctly
-        # Note that the new label metadata matches the nuc metadata
-        label_attrs = get_zattrs(zarr_url=f"{zarr_url}/labels/{label_name}")
-        _ = prepare_label_group(
-            image_group=zarr.group(zarr_url),
-            label_name=output_label_name,
-            overwrite=True,
-            label_attrs=label_attrs,
-            logger=logger,
-        )
-
-        new_label3d_array = zarr.create(
-            shape=shape,
-            chunks=chunks,
-            dtype=label_dtype,
-            store=store,
-            overwrite=True,
-            dimension_separator="/",
-        )
+        new_label3d_array = initialize_new_label(zarr_url, shape, chunks, np.uint32, label_name,
+                                                 output_label_name, logger)
 
         logger.info(f"Mask will have shape {shape} and chunks {chunks}")
 
@@ -218,113 +225,143 @@ def surface_mesh_multiscale(
     # Filter nuclei by parent mask ###
     ##############
 
-    # nuclei are masked by parent object (e.g. organoid) to only select nuclei belonging to parent.
-    # load well image as dask array for parent objects
-    r0_dask_parent = da.from_zarr(f"{zarr_url}/labels/{label_name_obj}/{level}")
+    if group_by is not None:
+        # Load group_by object segmentation to mask child objects by parent group_by object
+        # Load well image as dask array for parent objects
+        groupby_dask = da.from_zarr(f"{zarr_url}/labels/{group_by}/{level}")
 
-    # Read Zarr metadata
-    r0_ngffmeta_parent = load_NgffImageMeta(f"{zarr_url}/labels/{label_name_obj}")
-    r0_xycoars_parent = r0_ngffmeta_parent.coarsening_xy
-    r0_pixmeta_parent = r0_ngffmeta_parent.get_pixel_sizes_zyx(level=level)
+        # Read Zarr metadata
+        groupby_ngffmeta = load_NgffImageMeta(f"{zarr_url}/labels/{group_by}")
+        groupby_xycoars = groupby_ngffmeta.coarsening_xy
+        groupby_pixmeta = groupby_ngffmeta.get_pixel_sizes_zyx(level=level)
 
-    r0_idlist_parent = convert_ROI_table_to_indices(
-        r0_adata,
-        level=level,
-        coarsening_xy=r0_xycoars_parent,
-        full_res_pxl_sizes_zyx=r0_pixmeta_parent,
-    )
+        groupby_idlist = convert_ROI_table_to_indices(
+            roi_adata,
+            level=level,
+            coarsening_xy=groupby_xycoars,
+            full_res_pxl_sizes_zyx=groupby_pixmeta,
+        )
 
-    check_valid_ROI_indices(r0_idlist_parent, roi_table)
+        check_valid_ROI_indices(groupby_idlist, roi_table)
 
-    r0_labels = r0_adata.obs_vector('label')
-    # initialize variables
-    compute = True  # convert to numpy array from dask
-
-    # for each parent object (e.g. organoid) in r0...
+    # Get labels to iterate over
+    roi_labels = roi_adata.obs_vector('label')
+    total_label_count = len(roi_labels)
+    compute = True
     sphericity_flag = 0
     object_count = 0
-    for row in r0_adata.obs_names:
-        row_int = int(row)
-        r0_org_label = r0_labels[row_int]
-        region = convert_indices_to_regions(r0_idlist[row_int])
+    mesh_folder_name = None
 
-        # load nuclear label image for object in reference round
+    logger.info(f"Starting iteration over {total_label_count} detected objects in ROI table.")
+
+    # For each object in input ROI table...
+    for row in roi_adata.obs_names:
+        row_int = int(row)
+        label_str = roi_labels[row_int]
+        region = convert_indices_to_regions(roi_idlist[row_int])
+
+        # Load label image of label_name object as numpy array
         seg = load_region(
-            data_zyx=r0_dask,
+            data_zyx=label_dask,
             region=region,
             compute=compute,
         )
 
-        seg = mask_by_parent_object(seg, r0_dask_parent, r0_idlist_parent, row_int, r0_org_label)
+        if group_by is not None:
+            # Mask objects by parent group_by object
+            seg = mask_by_parent_object(seg, groupby_dask, groupby_idlist, row_int, label_str)
+        else:
+            # Check that label exists in object
+            if float(label_str) not in seg:
+                raise ValueError(f'Object ID {label_str} does not exist in loaded segmentation image. Does input ROI '
+                                 f'table match label map?')
+            # Select label that corresponds to current object, set all other objects to 0
+            seg[seg != float(label_str)] = 0
 
         ##############
         # Perform label fusion and edge detection  ###
         ##############
 
-        edges_canny, expandby_pix, iterations, anisotropic_sigma, padded_zslice_count = (
-            run_label_fusion(seg, expandby_factor, sigma_factor, r0_pixmeta, canny_threshold))
+        if multiscale:
 
-        if expandby_pix == 0:
-            logger.warning("Equivalent diameter is 0 or negative, thus labels not expanded. Check segmentation quality")
+            # Generate new 3D label image
+            edges_canny, expandby_pix, iterations, anisotropic_sigma, padded_zslice_count = (
+                run_label_fusion(seg, expandby_factor, sigma_factor, label_pixmeta, canny_threshold))
 
-        # Check whether new label map has a single value, otherwise result is discarded and object skipped
-        maxvalue = np.amax(edges_canny)
-        if maxvalue != 1:
-            if maxvalue == 0:
-                logger.warning(f'No 3D label and mesh saved for object {r0_org_label}. '
-                               f'Result of canny edge detection is empty')
-                continue
-            else:  # for max values greater than 1 or less than 0
-                logger.warning(f'No 3D label and mesh saved for object {r0_org_label}. Detected {maxvalue} labels. '
-                               f'Is the shape composed of {maxvalue} distinct objects?')
-                continue
-
-        logger.info(
-            f"Successfully calculated 3D label map for object label {r0_org_label} using parameters:"
-            f"\n\texpanded by {expandby_pix} pix, \n\teroded by {iterations*2} pix, "
-            f"\n\tgaussian blurred with sigma = {np.round(anisotropic_sigma,1)}"
-        )
-
-        if padded_zslice_count > 0:
-            logger.info(f'Object {r0_org_label} has non-zero pixels touching image border. Image processing '
-                        f'completed successfully, however consider reducing sigma_factor '
-                        f'or increasing the canny_threshold to reduce risk of cropping shape edges.')
-        object_count += 1
+            # Perform checks
+            if expandby_pix == 0:
+                logger.warning("Equivalent diameter is 0 or negative, thus labels not expanded. "
+                               "Check segmentation quality")
+            # Check whether new label map has a single value, otherwise result is discarded and object skipped
+            maxvalue = np.amax(edges_canny)
+            if maxvalue != 1:
+                if maxvalue == 0:
+                    logger.warning(f'No 3D label and mesh saved for object {label_str}. '
+                                   f'Result of canny edge detection is empty')
+                    continue
+                else:  # for max values greater than 1 or less than 0
+                    logger.warning(f'No 3D label and mesh saved for object {label_str}. Detected {maxvalue} labels. '
+                                   f'Is the shape composed of {maxvalue} distinct objects?')
+                    continue
+            logger.info(
+                f"Successfully calculated 3D label map for object label {label_str} using parameters:"
+                f"\n\texpanded by {expandby_pix} pix, \n\teroded by {iterations*2} pix, "
+                f"\n\tgaussian blurred with sigma = {np.round(anisotropic_sigma,1)}"
+            )
+            if padded_zslice_count > 0:
+                logger.info(f'Object {label_str} has non-zero pixels touching image border. Image processing '
+                            f'completed successfully, however consider reducing sigma_factor '
+                            f'or increasing the canny_threshold to reduce risk of cropping shape edges.')
 
         ##############
         # Calculate and save mesh  ###
         ##############
 
-        if calculate_mesh:
-            # Make mesh with vtkDiscreteFlyingEdges3D algorithm
-            # Set spacing to ome-zarr pixel spacing metadata. Mesh will be in physical units (um)
-            spacing = tuple(np.array(r0_pixmeta))  # z,y,x e.g. (0.6, 0.216, 0.216)
+        if save_mesh and multiscale:
+            # Mesh calculation for a new 3D object calculated from child objects (multiscale)
+            label_image = edges_canny
+            mesh_folder_name = f"{group_by}_from_{label_name}"
+            object_name = label_str
+            sphericity_check = True
+            save_as_stl = True
+        elif save_mesh and group_by is not None and multiscale is False:
+            # Mesh calculation for existing child objects that are part of the group_by object
+            label_image = seg
+            mesh_folder_name = f"{label_name}_grouped"
+            object_name = label_str
+            sphericity_check = False
+            # Save as .vtp, since .stl does not support multiple object labels
+            save_as_stl = False
+        elif save_mesh and group_by is None and multiscale is False:
+            label_image = seg
+            mesh_folder_name = f"{label_name}"
+            object_name = label_str
+            sphericity_check = True
+            save_as_stl = True
+        else:
+            logger.info(f"Skipping mesh saving. If this is undesired, did you input correct labels and ROI tables?")
+            continue
 
-            # Pad border with 0 so that the mesh forms a manifold
-            edges_canny_padded = np.pad(edges_canny, 1)
-            mesh_polydata_organoid = labels_to_mesh(edges_canny_padded, spacing,
-                                                    polynomial_degree=polynomial_degree,
-                                                    pass_band_param=passband,
-                                                    feature_angle=feature_angle,
-                                                    target_reduction=target_reduction,
-                                                    smoothing_iterations=smoothing_iterations,
-                                                    margin=5,
-                                                    show_progress=False)
-            # Save mesh
-            save_transform_path = f"{zarr_url}/meshes/{label_name_obj}_from_{label_name}"
-            os.makedirs(save_transform_path, exist_ok=True)
-            # Save name is the organoid label id
-            save_name = f"{int(r0_org_label)}.stl"
-            export_stl_polydata(os.path.join(save_transform_path, save_name), mesh_polydata_organoid)
+        # Check that label image contains an object
+        if np.amax(label_image) == 0:
+            logger.warning(f"Label image is empty. Skipping mesh saving!")
+            continue
 
-            logger.info(f"Successfully generated surface mesh for object label {r0_org_label}")
+        mesh_polydata = compute_and_save_mesh(label_image, label_pixmeta, polynomial_degree, passband, feature_angle,
+                                              target_reduction, smoothing_iterations, zarr_url,
+                                              mesh_folder_name, object_name, save_as_stl)
 
-            volume, surface_area = get_mass_properties(mesh_polydata_organoid)
+        object_count += 1
+
+        logger.info(f"Successfully generated surface mesh for object label {label_str}")
+
+        if sphericity_check:
+            volume, surface_area = get_mass_properties(mesh_polydata)
             sphr = mesh_sphericity(volume, surface_area)
 
             if sphr > 1.2:
                 logger.warning(
-                    f"Detected high sphericity = {np.round(sphr,3)} for object {r0_org_label}. "
+                    f"Detected high sphericity = {np.round(sphr,3)} for object {label_str}. "
                     f"Check mesh quality."
                 )
                 sphericity_flag += 1
@@ -333,78 +370,36 @@ def surface_mesh_multiscale(
         # Save labels and make ROI table ###
         ##############
 
-        if save_labels:
-            # store labels as new label map in zarr
-            # note that pixels of overlap in the case where two meshes are touching are overwritten by the last
+        if multiscale:
+            # Store labels as new label map in zarr
+            # Note that pixels of overlap in the case where two meshes are touching are overwritten by the last
             # written object
-            # thus meshes are the most accurate representation of surface, labels may be cropped
+            # Thus meshes are the most accurate representation of surface, labels may be cropped
 
-            # # TODO delete
-            # fake_numpy = np.zeros_like(seg)
-            # fake_numpy[1,2,2] = 2
-            #
-            # # Compute and store 0-th level to disk
-            # da.array(fake_numpy).to_zarr(
-            #     url=new_label3d_array,
-            #     region=region,
-            #     compute=True,
-            # )
-
-            # load dask from disk, will contain rois of the previously processed objects within for loop
-            new_label3d_dask = da.from_zarr(f"{zarr_url}/labels/{output_label_name}/0")
-            # load region of current object from disk, will include any previously processed neighboring objects
-            seg_ondisk = load_region(
-                data_zyx=new_label3d_dask,
-                region=region,
-                compute=compute,
-            )
-
-            # check that dimensions of rois match
-            if seg_ondisk.shape != edges_canny.shape:
-                raise ValueError('Computed label image must match image dimensions of bounding box during saving')
-
-            # convert edge detection label image value to match object label id
-            edges_canny_label = edges_canny * int(r0_org_label)
-            # use fmax so that if one of the elements being compared is a NaN, then the non-nan element is returned
-            edges_canny_label_tosave = np.fmax(edges_canny_label, seg_ondisk)
-
-            # Compute and store 0-th level of new 3d label map to disk
-            da.array(edges_canny_label_tosave).to_zarr(
-                url=new_label3d_array,
-                region=region,
-                compute=True,
-            )
-
-            # make new ROI table
-            origin_zyx = convert_indices_to_origin_zyx(r0_idlist[row_int])
-
-            bbox_df = array_to_bounding_box_table(
-                edges_canny_label,
-                r0_pixmeta,
-                origin_zyx=origin_zyx,
-            )
-
+            bbox_df = save_new_label_with_overlap(edges_canny, label_str, new_label3d_array, zarr_url,
+                                                  output_label_name, region, label_pixmeta, compute,
+                                                  roi_idlist, row_int)
             bbox_dataframe_list.append(bbox_df)
 
             overlap_list = []
             for df in bbox_dataframe_list:
                 overlap_list.extend(
-                    get_overlapping_pairs_3D(df, r0_pixmeta)
+                    get_overlapping_pairs_3D(df, label_pixmeta)
                 )
+
             if len(overlap_list) > 0:
                 logger.warning(
                     f"{len(overlap_list)} bounding-box pairs overlap"
                 )
 
-    # Starting from on-disk highest-resolution data, build and write to disk a
-    # pyramid of coarser levels
-    if save_labels:
+    # Starting from on-disk highest-resolution data, build and write to disk a pyramid of coarser levels
+    if multiscale:
 
         build_pyramid(
             zarrurl=f"{zarr_url}/labels/{output_label_name}",
             overwrite=True,
-            num_levels=r0_ngffmeta.num_levels,
-            coarsening_xy=r0_ngffmeta.coarsening_xy,
+            num_levels=label_ngffmeta.num_levels,
+            coarsening_xy=label_ngffmeta.coarsening_xy,
             chunksize=chunks,
             aggregation_function=np.max,
         )
@@ -429,7 +424,7 @@ def surface_mesh_multiscale(
             table_attrs=table_attrs,
         )
 
-    if calculate_mesh:
+    if save_mesh and multiscale:
         # Check how many objects out of well have a sphericity flag
         logger.info(f"{sphericity_flag} out of {object_count} meshed objects are flagged for high sphericity, "
                     f"which can indicate a highly complex mesh surface.")
@@ -437,8 +432,10 @@ def surface_mesh_multiscale(
             # if more than 10% of objects have a sphericity flag, raise warning
             logger.warning(f"Detected high fraction of suspicious organoid meshes in well. Inspect mesh quality "
                            f"and tune task parameters for label expansion and mesh smoothing accordingly. ")
-
-    logger.info(f"End surface_mesh_multiscale task for {zarr_url}/labels/{output_label_name}")
+    if save_mesh:
+        logger.info(f"Meshes saved in folder name {mesh_folder_name}")
+    logger.info(f"Successfully processed {object_count} out of {total_label_count} labels.")
+    logger.info(f"End surface_mesh_multiscale task for {zarr_url}/labels/{label_name}")
 
     return {}
 

--- a/src/scmultiplex/linking/NucleiLinkingFunctions.py
+++ b/src/scmultiplex/linking/NucleiLinkingFunctions.py
@@ -364,7 +364,6 @@ def relabel_RX_numpy(rx_seg, matches, moving_colname='RX_nuc_id', fixed_colname=
     """
     # key is moving_label, value is fixed_label
     matching_dict = make_linking_dict(matches, moving_colname, fixed_colname)
-
     # convert to numpy if input is not numpy (e.g. if input is a dask array)
     if not isinstance(rx_seg, np.ndarray):
         rx_seg = np.asarray(rx_seg)
@@ -379,8 +378,8 @@ def relabel_RX_numpy(rx_seg, matches, moving_colname='RX_nuc_id', fixed_colname=
     labels_in_output = set()
     for nonzero_pixel in zip(*rx_seg_nonzero):
 
-        key = rx_seg[nonzero_pixel].item()
-        labels_in_input.add(key)
+        key = rx_seg[nonzero_pixel].item()  # fetch value of given pixel
+        labels_in_input.add(key)  # add key to set
 
         try:
             relabeled_value = matching_dict[key]
@@ -396,7 +395,7 @@ def relabel_RX_numpy(rx_seg, matches, moving_colname='RX_nuc_id', fixed_colname=
     if daskarr:
         rx_numpy_matched = da.from_array(rx_numpy_matched)
 
-    return rx_numpy_matched, count_input, count_output
+    return rx_numpy_matched, count_input, count_output, labels_in_output
 
 
 def remove_labels(seg_img, labels_to_remove, datatype):

--- a/src/scmultiplex/meshing/FilterFunctions.py
+++ b/src/scmultiplex/meshing/FilterFunctions.py
@@ -67,19 +67,6 @@ def calculate_mean_volume(seg):
     return size_mean
 
 
-def equivalent_diam(volume):
-    """
-    Calculate equivalent diameter of sphere with a given volume
-    """
-    try:
-        diameter = 2 * math.pow((0.75 * (1/np.pi) * volume), (1/3))
-    # ValueError is raised when input value is negative
-    # in this case set diameter to 0
-    except ValueError:
-        diameter = 0
-    return diameter
-
-
 def mask_by_parent_object(seg, parent_dask, parent_idlist_parentmeta, row_int, parent_label_id):
     """
     Mask input numpy array (seg) by parent numpy array (region loaded from dask_parent)

--- a/src/scmultiplex/meshing/LabelFusionFunctions.py
+++ b/src/scmultiplex/meshing/LabelFusionFunctions.py
@@ -56,8 +56,8 @@ def anisotropic_gaussian_blur(seg_binary, sigma, pixmeta):
     seg_fill_8bit = (seg_binary * 255).astype(np.uint8)
 
     # Scale sigma to match pixel anisotropy
-    pixel_anisotropy = pixmeta[0]/np.array(pixmeta)  # (z, y, x) where z is normalized to 1, e.g. (1, 3, 3)
-    anisotropic_sigma = tuple([sigma * x for x in pixel_anisotropy])
+    spacing = np.array(pixmeta)/pixmeta[1]  # (z, y, x) where x,y is normalized to 1 e.g. (3, 1, 1)
+    anisotropic_sigma = tuple([sigma * (spacing[1] / x) for x in spacing])
 
     # Perform 3D gaussian blur
     # Output image has value range 0-1 (not always max 1)

--- a/src/scmultiplex/meshing/LabelFusionFunctions.py
+++ b/src/scmultiplex/meshing/LabelFusionFunctions.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2024 Friedrich Miescher Institute for Biomedical Research
+
+##############################################################################
+#                                                                            #
+# Author: Nicole Repina              <nicole.repina@fmi.ch>                  #
+#                                                                            #
+##############################################################################
+
+import numpy as np
+from scipy.ndimage import binary_fill_holes, binary_erosion
+from skimage.morphology import disk, remove_small_objects
+from skimage.segmentation import expand_labels
+from skimage.feature import canny
+from skimage.filters import gaussian
+from skimage.measure import label
+
+from scmultiplex.features.FeatureFunctions import mesh_equivalent_diameter
+from scmultiplex.meshing.FilterFunctions import calculate_mean_volume, load_border_values, remove_border
+
+
+def fuse_labels(seg, expandby_factor):
+    """
+    Expand labels in 3D image by 2D z-slice based on the mean volume, fuse and fill holes,
+    and erode back to original size.
+    """
+    # Initialize empty array
+    seg_binary = np.zeros_like(seg)
+
+    # Determine the expansion amount (in pixels) based on the mean diameter of 3D nuclei or cells in object
+    size_mean = calculate_mean_volume(seg)
+    expandby_pix = int(round(expandby_factor * mesh_equivalent_diameter(size_mean)))
+
+    # Determine the number of iterations for binary erosions to reverse the expansion
+    # The number of iterations is roughly half of the expansion, since erosion is
+    # performed with a disk size of diameter 2
+    iterations = int(round(expandby_pix / 2))
+
+    # Iterate over each zslice in image
+    for i, zslice in enumerate(seg):
+        # Expand labels in x,y
+        zslice = expand_labels(zslice, expandby_pix)
+        # Fill holes and binarize area (return boolean)
+        zslice = binary_fill_holes(zslice)
+        # Revert the expansion (i.e. erode down to original size)
+        # Erode by half of the expanded pixels since disk(1) has a radius of 1, i.e. diameter of 2
+        seg_binary[i, :, :] = binary_erosion(zslice, disk(1), iterations=iterations)  # returns binary image, max val 1
+
+    return seg_binary, expandby_pix, iterations
+
+
+def anisotropic_gaussian_blur(seg_binary, sigma, pixmeta):
+    """
+    Perform gaussian blur of binary 3D image with anisotropic sigma. Sigma anisotropy calculated from pixel spacing.
+    """
+    # Convert binary segmentation into 8-bit image
+    seg_fill_8bit = (seg_binary * 255).astype(np.uint8)
+
+    # Scale sigma to match pixel anisotropy
+    pixel_anisotropy = pixmeta[0]/np.array(pixmeta)  # (z, y, x) where z is normalized to 1, e.g. (1, 3, 3)
+    anisotropic_sigma = tuple([sigma * x for x in pixel_anisotropy])
+
+    # Perform 3D gaussian blur
+    # Output image has value range 0-1 (not always max 1)
+    blurred = gaussian(seg_fill_8bit, sigma=anisotropic_sigma, preserve_range=False)
+
+    return blurred, anisotropic_sigma
+
+
+def find_edges(blurred, canny_threshold, iterations):
+    """
+    Find edges of input 3D image by z-slice
+    """
+    # Initialize empty array
+    edges_canny = np.zeros_like(blurred)
+
+    # Values below Canny threshold are set to 0. This is similar to setting a contour value.
+    blurred[blurred < canny_threshold] = 0
+
+    # Count the number of zslices that require padding
+    padded_zslice_count = 0
+
+    # Iterate over each zslice in image
+    for i, zslice in enumerate(blurred):
+
+        padded = False
+
+        # If zslice is empty, skip the zslice
+        if np.count_nonzero(zslice) == 0:
+            continue
+        else:
+            # Get pixel values at borders of image
+            image_border = load_border_values(zslice)
+
+            # If any values are non-zero, object is touching image edge and thus requires zero-padding
+            # This ensures that Canny filter generates a closed surface
+            if np.any(image_border):
+                zslice = np.pad(zslice, 1)
+                padded_zslice_count += 1
+                padded = True
+
+            # Perform edge detection with Canny filter (see skimage documentation)
+            edges = canny(zslice)
+
+            # Fill to generate solid object
+            edges = binary_fill_holes(edges)
+
+            # Remove padding
+            if padded:
+                edges = remove_border(edges)
+
+            edges_canny[i, :, :] = edges
+
+    # Convert to 8-bit image
+    edges_canny = (edges_canny * 255).astype(np.uint8)
+
+    # Filter out small objects that are smaller than radius of expansion and convert to labelmap
+    edges_canny = label(remove_small_objects(edges_canny, iterations))
+
+    return edges_canny, padded_zslice_count
+
+
+def run_label_fusion(seg, expandby_factor, sigma, pixmeta, canny_threshold):
+    """
+    Main function for running label fusion. Used in Surface Mesh Multiscale task to generate organoid label from
+    single-cell segmentation.
+    """
+    seg_binary, expandby_pix, iterations = fuse_labels(seg, expandby_factor)
+    blurred, anisotropic_sigma = anisotropic_gaussian_blur(seg_binary, sigma, pixmeta)
+    edges_canny, padded_zslice_count = find_edges(blurred, canny_threshold, iterations)
+
+    return edges_canny, expandby_pix, iterations, anisotropic_sigma, padded_zslice_count


### PR DESCRIPTION
- Generalize surface mesh task to handle multiple mesh inputs (both multiscale and simple mesh generation from input label images)
- Clean up surface mesh helper functions
- Refactor Canny edge detection functions for multiscale task
- Standardize scaling of Gaussian blur during edge detection
- Improve logging and consistency checks for ROI tables during consensus relabelling 