### PR TITLE
Update fractal tasks core dep, pre-commit cleanup & manifest update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        args: [ "--ignore=E203,E501,W504,W503,E731", "--max-complexity=15"]
+        args: [ "--ignore=E203,E501,W504,W503,E731,C901", "--max-complexity=15"]
         additional_dependencies: [ flake8-typing-imports==1.12.0 ]
   - repo: https://github.com/myint/autoflake
     rev: v1.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ write_to = "src/scmultiplex/_version.py"
 [tool.pytest.ini_options]
 log_cli = "True"
 log_cli_level = "INFO"
+
+[tool.coverage.run]
+source = ["src/scmultiplex"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ where = src
 [options.extras_require]
 fractal-tasks =
     anndata
-    fractal-tasks-core==1.0.2
+    fractal-tasks-core==1.2.1
 plotting =
     anndata
     dask

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     matplotlib
     numba
     numcodecs
-    numpy==1.23.5
+    numpy<2
     pandas
     pyshtools
     scikit-image>=0.21.0

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -14,15 +14,14 @@
         "mem": 16000
       },
       "args_schema_non_parallel": {
-        "title": "ImageBasedRegistrationHcsInit",
-        "type": "object",
+        "additionalProperties": false,
         "properties": {
           "zarr_urls": {
-            "title": "Zarr Urls",
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "title": "Zarr Urls",
+            "type": "array",
             "description": "List of paths or urls to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "zarr_dir": {
@@ -31,8 +30,8 @@
             "description": "path of the directory where the new OME-Zarrs will be created. Not used by this task. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "reference_acquisition": {
-            "title": "Reference Acquisition",
             "default": 0,
+            "title": "Reference Acquisition",
             "type": "integer",
             "description": "Which acquisition to register against. Needs to match the acquisition metadata in the OME-Zarr image."
           }
@@ -41,11 +40,27 @@
           "zarr_urls",
           "zarr_dir"
         ],
-        "additionalProperties": false
+        "type": "object",
+        "title": "ImageBasedRegistrationHcsInit"
       },
       "args_schema_parallel": {
-        "title": "CalculateObjectLinking",
-        "type": "object",
+        "$defs": {
+          "InitArgsRegistration": {
+            "description": "Registration init args.",
+            "properties": {
+              "reference_zarr_url": {
+                "title": "Reference Zarr Url",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reference_zarr_url"
+            ],
+            "title": "InitArgsRegistration",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
         "properties": {
           "zarr_url": {
             "title": "Zarr Url",
@@ -53,8 +68,8 @@
             "description": "Path or url to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "init_args": {
-            "$ref": "#/definitions/InitArgsRegistration",
-            "title": "Init_Args",
+            "$ref": "#/$defs/InitArgsRegistration",
+            "title": "Init Args",
             "description": "Intialization arguments provided by `_image_based_registration_hcs_init`. They contain the reference_zarr_url that is used for registration. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "label_name": {
@@ -63,20 +78,20 @@
             "description": "Label name that will be used for label-based registration; e.g. `org` from object segmentation."
           },
           "roi_table": {
-            "title": "Roi Table",
             "default": "well_ROI_table",
+            "title": "Roi Table",
             "type": "string",
             "description": "Name of the well ROI table. Input ROI table must have single ROI entry; e.g. `well_ROI_table`"
           },
           "level": {
-            "title": "Level",
             "default": 0,
+            "title": "Level",
             "type": "integer",
             "description": "Pyramid level of the image to be processed. Choose `0` to process at full resolution."
           },
           "iou_cutoff": {
-            "title": "Iou Cutoff",
             "default": 0.2,
+            "title": "Iou Cutoff",
             "type": "number",
             "description": "Float in range 0 to 1 to specify intersection over union cutoff. Object pairs that have an iou below this value are filtered out and not stored in linking table."
           }
@@ -86,23 +101,8 @@
           "init_args",
           "label_name"
         ],
-        "additionalProperties": false,
-        "definitions": {
-          "InitArgsRegistration": {
-            "title": "InitArgsRegistration",
-            "description": "Registration init args.",
-            "type": "object",
-            "properties": {
-              "reference_zarr_url": {
-                "title": "Reference Zarr Url",
-                "type": "string"
-              }
-            },
-            "required": [
-              "reference_zarr_url"
-            ]
-          }
-        }
+        "type": "object",
+        "title": "CalculateObjectLinking"
       },
       "docs_info": "## _image_based_registration_hcs_init\nInitialized calculate registration task\n\nThis task prepares a parallelization list of all zarr_urls that need to be\nused to calculate the registration between acquisitions (all zarr_urls\nexcept the reference acquisition vs. the reference acquisition).\nThis task only works for HCS OME-Zarrs for 2 reasons: Only HCS OME-Zarrs\ncurrently have defined acquisition metadata to determine reference\nacquisitions. And we have only implemented the grouping of images for\nHCS OME-Zarrs by well (with the assumption that every well just has 1\nimage per acqusition).\n## calculate_object_linking\nCalculate object linking based on segmentation label map images\n\nThis task consists of 4 parts:\n\n1. Load the object segmentation images for each well (paired reference and alignment round)\n2. Calculate the shift transformation for the image pair\n3. Apply shifts to image pair and identify matching object labels given an iou cutoff threshold\n3. Store the identified matches as a linking table in alignment round directory\n\nParallelization level: image\n"
     },
@@ -119,15 +119,14 @@
         "mem": 16000
       },
       "args_schema_non_parallel": {
-        "title": "InitGroupByWellForMultiplexing",
-        "type": "object",
+        "additionalProperties": false,
         "properties": {
           "zarr_urls": {
-            "title": "Zarr Urls",
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "title": "Zarr Urls",
+            "type": "array",
             "description": "List of paths or urls to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "zarr_dir": {
@@ -136,8 +135,8 @@
             "description": "path of the directory where the new OME-Zarrs will be created. Not used by this task. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "reference_acquisition": {
-            "title": "Reference Acquisition",
             "default": 0,
+            "title": "Reference Acquisition",
             "type": "integer",
             "description": "Which acquisition to register against. Uses the OME-NGFF HCS well metadata acquisition keys to find the reference acquisition."
           }
@@ -146,11 +145,30 @@
           "zarr_urls",
           "zarr_dir"
         ],
-        "additionalProperties": false
+        "type": "object",
+        "title": "InitGroupByWellForMultiplexing"
       },
       "args_schema_parallel": {
-        "title": "CalculateLinkingConsensus",
-        "type": "object",
+        "$defs": {
+          "InitArgsRegistrationConsensus": {
+            "description": "Registration consensus init args.",
+            "properties": {
+              "zarr_url_list": {
+                "items": {
+                  "type": "string"
+                },
+                "title": "Zarr Url List",
+                "type": "array"
+              }
+            },
+            "required": [
+              "zarr_url_list"
+            ],
+            "title": "InitArgsRegistrationConsensus",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
         "properties": {
           "zarr_url": {
             "title": "Zarr Url",
@@ -158,13 +176,13 @@
             "description": "Path or url to the individual OME-Zarr image to be processed. Refers to the zarr_url of the reference acquisition. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "init_args": {
-            "$ref": "#/definitions/InitArgsRegistrationConsensus",
-            "title": "Init_Args",
+            "$ref": "#/$defs/InitArgsRegistrationConsensus",
+            "title": "Init Args",
             "description": "Intialization arguments provided by `init_group_by_well_for_multiplexing`. It contains the zarr_url_list listing all the zarr_urls in the same well as the zarr_url of the reference acquisition that are being processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "roi_table": {
-            "title": "Roi Table",
             "default": "org_match_table",
+            "title": "Roi Table",
             "type": "string",
             "description": "Name of the matching table used to calculate consensus across multiplexing rounds. Typically, this matching table is the output of a linking task, e.g. org_match_table or nuc_match_table. This table must be present in all rounds except for reference round."
           }
@@ -173,26 +191,8 @@
           "zarr_url",
           "init_args"
         ],
-        "additionalProperties": false,
-        "definitions": {
-          "InitArgsRegistrationConsensus": {
-            "title": "InitArgsRegistrationConsensus",
-            "description": "Registration consensus init args.",
-            "type": "object",
-            "properties": {
-              "zarr_url_list": {
-                "title": "Zarr Url List",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": [
-              "zarr_url_list"
-            ]
-          }
-        }
+        "type": "object",
+        "title": "CalculateLinkingConsensus"
       },
       "docs_info": "## _init_group_by_well_for_multiplexing\nFinds images for all acquisitions per well.\n\nReturns the parallelization_list to run `find_registration_consensus`.\n## calculate_linking_consensus\nApplies pre-calculated registration to ROI tables.\n\nApply pre-calculated registration such that resulting ROIs contain\nthe consensus align region between all cycles.\n\nParallelization level: well\n"
     },
@@ -209,15 +209,14 @@
         "mem": 64000
       },
       "args_schema_non_parallel": {
-        "title": "ImageBasedRegistrationHcsAllroundsInit",
-        "type": "object",
+        "additionalProperties": false,
         "properties": {
           "zarr_urls": {
-            "title": "Zarr Urls",
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "title": "Zarr Urls",
+            "type": "array",
             "description": "List of paths or urls to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "zarr_dir": {
@@ -226,8 +225,8 @@
             "description": "path of the directory where the new OME-Zarrs will be created. Not used by this task. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "reference_acquisition": {
-            "title": "Reference Acquisition",
             "default": 0,
+            "title": "Reference Acquisition",
             "type": "integer",
             "description": "Which acquisition to register against. Needs to match the acquisition metadata in the OME-Zarr image."
           }
@@ -236,11 +235,27 @@
           "zarr_urls",
           "zarr_dir"
         ],
-        "additionalProperties": false
+        "type": "object",
+        "title": "ImageBasedRegistrationHcsAllroundsInit"
       },
       "args_schema_parallel": {
-        "title": "RelabelByLinkingConsensus",
-        "type": "object",
+        "$defs": {
+          "InitArgsRegistration": {
+            "description": "Registration init args.",
+            "properties": {
+              "reference_zarr_url": {
+                "title": "Reference Zarr Url",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reference_zarr_url"
+            ],
+            "title": "InitArgsRegistration",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
         "properties": {
           "zarr_url": {
             "title": "Zarr Url",
@@ -248,8 +263,8 @@
             "description": "Path or url to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "init_args": {
-            "$ref": "#/definitions/InitArgsRegistration",
-            "title": "Init_Args",
+            "$ref": "#/$defs/InitArgsRegistration",
+            "title": "Init Args",
             "description": "Intialization arguments provided by `_image_based_registration_hcs_init`. They contain the reference_zarr_url that is used for registration. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "label_name": {
@@ -258,14 +273,14 @@
             "description": "Label name to be relabeled; e.g. `org` or `nuc`."
           },
           "consensus_table": {
-            "title": "Consensus Table",
             "default": "org_match_table_consensus",
+            "title": "Consensus Table",
             "type": "string",
             "description": "Name of consensus matching table that specifies consensus matches across rounds, typically stored in reference round zarr."
           },
           "table_to_relabel": {
-            "title": "Table To Relabel",
             "default": "org_ROI_table",
+            "title": "Table To Relabel",
             "type": "string",
             "description": "Table name to relabel based on consensus linking. The table rows correspond to specified 'Label name', e.g. 'org_ROI_table' or 'nuc_ROI_table'"
           }
@@ -275,23 +290,8 @@
           "init_args",
           "label_name"
         ],
-        "additionalProperties": false,
-        "definitions": {
-          "InitArgsRegistration": {
-            "title": "InitArgsRegistration",
-            "description": "Registration init args.",
-            "type": "object",
-            "properties": {
-              "reference_zarr_url": {
-                "title": "Reference Zarr Url",
-                "type": "string"
-              }
-            },
-            "required": [
-              "reference_zarr_url"
-            ]
-          }
-        }
+        "type": "object",
+        "title": "RelabelByLinkingConsensus"
       },
       "docs_info": "## _image_based_registration_hcs_allrounds_init\nInitialized calculate registration task\n\nSame as _image_based_registration_hcs_init.py only does not exclude reference round in zarr_url list;\nall rounds are processed.\n## relabel_by_linking_consensus\nRelabels image labels and ROI tables based on consensus linking.\n\nParallelization level: image\n"
     },
@@ -308,15 +308,14 @@
         "mem": 16000
       },
       "args_schema_non_parallel": {
-        "title": "ImageBasedRegistrationHcsInit",
-        "type": "object",
+        "additionalProperties": false,
         "properties": {
           "zarr_urls": {
-            "title": "Zarr Urls",
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "title": "Zarr Urls",
+            "type": "array",
             "description": "List of paths or urls to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "zarr_dir": {
@@ -325,8 +324,8 @@
             "description": "path of the directory where the new OME-Zarrs will be created. Not used by this task. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "reference_acquisition": {
-            "title": "Reference Acquisition",
             "default": 0,
+            "title": "Reference Acquisition",
             "type": "integer",
             "description": "Which acquisition to register against. Needs to match the acquisition metadata in the OME-Zarr image."
           }
@@ -335,11 +334,44 @@
           "zarr_urls",
           "zarr_dir"
         ],
-        "additionalProperties": false
+        "type": "object",
+        "title": "ImageBasedRegistrationHcsInit"
       },
       "args_schema_parallel": {
-        "title": "CalculatePlatymatchRegistration",
-        "type": "object",
+        "$defs": {
+          "ChannelInputModel": {
+            "description": "A channel which is specified by either `wavelength_id` or `label`.",
+            "properties": {
+              "wavelength_id": {
+                "title": "Wavelength Id",
+                "type": "string",
+                "description": "Unique ID for the channel wavelength, e.g. `A01_C01`. Can only be specified if label is not set."
+              },
+              "label": {
+                "title": "Label",
+                "type": "string",
+                "description": "Name of the channel. Can only be specified if wavelength_id is not set."
+              }
+            },
+            "title": "ChannelInputModel",
+            "type": "object"
+          },
+          "InitArgsRegistration": {
+            "description": "Registration init args.",
+            "properties": {
+              "reference_zarr_url": {
+                "title": "Reference Zarr Url",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reference_zarr_url"
+            ],
+            "title": "InitArgsRegistration",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
         "properties": {
           "zarr_url": {
             "title": "Zarr Url",
@@ -347,66 +379,66 @@
             "description": "Path or url to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "init_args": {
-            "$ref": "#/definitions/InitArgsRegistration",
-            "title": "Init_Args",
+            "$ref": "#/$defs/InitArgsRegistration",
+            "title": "Init Args",
             "description": "Intialization arguments provided by `_image_based_registration_hcs_init`. They contain the reference_zarr_url that is used for registration. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "seg_channel": {
-            "$ref": "#/definitions/ChannelInputModel",
-            "title": "Seg_Channel",
+            "$ref": "#/$defs/ChannelInputModel",
+            "title": "Seg Channel",
             "description": "Channel that was used for nuclear segmentation; requires either `wavelength_id` (e.g. `A01_C01`) or `label` (e.g. `DAPI`). Assume same across all rounds."
           },
           "label_name_to_register": {
-            "title": "Label Name To Register",
             "default": "nuc",
+            "title": "Label Name To Register",
             "type": "string",
             "description": "Label name that will be used for label-based registration, e.g. `nuc`."
           },
           "label_name_obj": {
-            "title": "Label Name Obj",
             "default": "org_linked",
+            "title": "Label Name Obj",
             "type": "string",
             "description": "Label name of segmented objects that is parent of label_name_to_register e.g. `org_linked`."
           },
           "roi_table": {
-            "title": "Roi Table",
             "default": "org_ROI_table_linked",
+            "title": "Roi Table",
             "type": "string",
             "description": "Name of the ROI table over which the task loops to calculate the registration. e.g. linked consensus object table 'org_ROI_table_linked'"
           },
           "level": {
-            "title": "Level",
             "default": 0,
+            "title": "Level",
             "type": "integer",
             "description": "Pyramid level of the labels to register. Choose `0` to process at full resolution."
           },
           "save_transformation": {
-            "title": "Save Transformation",
             "default": true,
+            "title": "Save Transformation",
             "type": "boolean",
             "description": "if True, saves the transformation matrix on disk in subfolder 'transformations'"
           },
           "mask_by_parent": {
-            "title": "Mask By Parent",
             "default": true,
+            "title": "Mask By Parent",
             "type": "boolean",
             "description": "if True, nuclei are masked by parent object (e.g. organoid) to only select nuclei belonging to parent. Recommended to set to True when iterating over object (e.g. organoid) ROIs."
           },
           "calculate_ffd": {
-            "title": "Calculate Ffd",
             "default": true,
+            "title": "Calculate Ffd",
             "type": "boolean",
             "description": "if True, calculate free form deformation registration based on affine linking."
           },
           "volume_filter": {
-            "title": "Volume Filter",
             "default": true,
+            "title": "Volume Filter",
             "type": "boolean",
             "description": "if True, performing volume filtering of nuclei to remove objects smaller than specified volume_filter_threshold."
           },
           "volume_filter_threshold": {
-            "title": "Volume Filter Threshold",
             "default": 0.05,
+            "title": "Volume Filter Threshold",
             "type": "number",
             "description": "Multiplier that specifies cutoff for volumes below which nuclei are filtered out, float in range [0,1], e.g. 0.05 means that 5% of median of nuclear volume distribution is used as cutoff. Specify this value if volume filtering is desired. Default 0.05."
           }
@@ -416,40 +448,8 @@
           "init_args",
           "seg_channel"
         ],
-        "additionalProperties": false,
-        "definitions": {
-          "InitArgsRegistration": {
-            "title": "InitArgsRegistration",
-            "description": "Registration init args.",
-            "type": "object",
-            "properties": {
-              "reference_zarr_url": {
-                "title": "Reference Zarr Url",
-                "type": "string"
-              }
-            },
-            "required": [
-              "reference_zarr_url"
-            ]
-          },
-          "ChannelInputModel": {
-            "title": "ChannelInputModel",
-            "description": "A channel which is specified by either `wavelength_id` or `label`.",
-            "type": "object",
-            "properties": {
-              "wavelength_id": {
-                "title": "Wavelength Id",
-                "type": "string",
-                "description": "Unique ID for the channel wavelength, e.g. `A01_C01`."
-              },
-              "label": {
-                "title": "Label",
-                "type": "string",
-                "description": "Name of the channel."
-              }
-            }
-          }
-        }
+        "type": "object",
+        "title": "CalculatePlatymatchRegistration"
       },
       "docs_info": "## _image_based_registration_hcs_init\nInitialized calculate registration task\n\nThis task prepares a parallelization list of all zarr_urls that need to be\nused to calculate the registration between acquisitions (all zarr_urls\nexcept the reference acquisition vs. the reference acquisition).\nThis task only works for HCS OME-Zarrs for 2 reasons: Only HCS OME-Zarrs\ncurrently have defined acquisition metadata to determine reference\nacquisitions. And we have only implemented the grouping of images for\nHCS OME-Zarrs by well (with the assumption that every well just has 1\nimage per acqusition).\n## calculate_platymatch_registration\nCalculate point-cloud-based registration with PlatyMatch.\n\nThis task consists of 4 parts:\n\n1. Load the sub-object segmentation images for each well (paired reference and alignment round)\n2. Select sub-objects that belong to object region by loading with object ROI table and mask by object mask.\n   Object pair is defined by consensus linking. Filter the sub-objects to remove small debris that was segmented.\n3. Calculate affine and optionally the free-form deformation for each object pair\n4. Output: save the identified matches as a linking table in alignment round directory\n   and optionally the transformation matrix on disk.\n\nParallelization level: image\n"
     },
@@ -466,15 +466,14 @@
         "mem": 16000
       },
       "args_schema_non_parallel": {
-        "title": "InitGroupByWellForMultiplexing",
-        "type": "object",
+        "additionalProperties": false,
         "properties": {
           "zarr_urls": {
-            "title": "Zarr Urls",
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "title": "Zarr Urls",
+            "type": "array",
             "description": "List of paths or urls to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "zarr_dir": {
@@ -483,8 +482,8 @@
             "description": "path of the directory where the new OME-Zarrs will be created. Not used by this task. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "reference_acquisition": {
-            "title": "Reference Acquisition",
             "default": 0,
+            "title": "Reference Acquisition",
             "type": "integer",
             "description": "Which acquisition to register against. Uses the OME-NGFF HCS well metadata acquisition keys to find the reference acquisition."
           }
@@ -493,11 +492,30 @@
           "zarr_urls",
           "zarr_dir"
         ],
-        "additionalProperties": false
+        "type": "object",
+        "title": "InitGroupByWellForMultiplexing"
       },
       "args_schema_parallel": {
-        "title": "SurfaceMeshMultiscale",
-        "type": "object",
+        "$defs": {
+          "InitArgsRegistrationConsensus": {
+            "description": "Registration consensus init args.",
+            "properties": {
+              "zarr_url_list": {
+                "items": {
+                  "type": "string"
+                },
+                "title": "Zarr Url List",
+                "type": "array"
+              }
+            },
+            "required": [
+              "zarr_url_list"
+            ],
+            "title": "InitArgsRegistrationConsensus",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
         "properties": {
           "zarr_url": {
             "title": "Zarr Url",
@@ -505,85 +523,85 @@
             "description": "Path or url to the individual OME-Zarr image to be processed. Refers to the zarr_url of the reference acquisition. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "init_args": {
-            "$ref": "#/definitions/InitArgsRegistrationConsensus",
-            "title": "Init_Args",
+            "$ref": "#/$defs/InitArgsRegistrationConsensus",
+            "title": "Init Args",
             "description": "Intialization arguments provided by `init_group_by_well_for_multiplexing`. It contains the zarr_url_list listing all the zarr_urls in the same well as the zarr_url of the reference acquisition that are being processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "label_name": {
-            "title": "Label Name",
             "default": "nuc",
+            "title": "Label Name",
             "type": "string",
             "description": "Label name of child objects that will be used for multiscale surface estimation, e.g. `nuc`."
           },
           "label_name_obj": {
-            "title": "Label Name Obj",
             "default": "org_linked",
+            "title": "Label Name Obj",
             "type": "string",
             "description": "Label name of segmented objects that are parents of label_name e.g. `org`."
           },
           "roi_table": {
-            "title": "Roi Table",
             "default": "org_ROI_table_linked",
+            "title": "Roi Table",
             "type": "string",
             "description": "Name of the ROI table that corresponds to label_name_obj. The task loops over ROIs in this table to load the corresponding child objects."
           },
           "expandby_factor": {
-            "title": "Expandby Factor",
             "default": 0.6,
+            "title": "Expandby Factor",
             "type": "number",
             "description": "multiplier that specifies pixels by which to expand each nuclear mask for merging, float in range [0, 1 or higher], e.g. 0.2 means that 20% of mean of nuclear equivalent diameter is used."
           },
           "sigma_factor": {
-            "title": "Sigma Factor",
             "default": 5,
+            "title": "Sigma Factor",
             "type": "number",
             "description": "float that specifies sigma (standard deviation, in pixels) for Gaussian kernel used for blurring to smoothen label image prior to edge detection. Higher values correspond to more blurring. Recommended range 1-8."
           },
           "canny_threshold": {
-            "title": "Canny Threshold",
             "default": 0.3,
+            "title": "Canny Threshold",
             "type": "number",
             "description": "image values below this threshold are set to 0 after Gaussian blur. float in range [0,1]. Higher values result in tighter fit of mesh to nuclear surface"
           },
           "calculate_mesh": {
-            "title": "Calculate Mesh",
             "default": true,
+            "title": "Calculate Mesh",
             "type": "boolean",
             "description": "if True, saves the mesh as .stl on disk in meshes/[labelname] folder within zarr structure. Filename corresponds to object label id"
           },
           "polynomial_degree": {
-            "title": "Polynomial Degree",
             "default": 30,
+            "title": "Polynomial Degree",
             "type": "integer",
             "description": "the number of polynomial degrees during surface mesh smoothing with vtkWindowedSincPolyDataFilter determines the maximum number of smoothing passes. This number corresponds to the degree of the polynomial that is used to approximate the windowed sinc function. Usually 10-20 iteration are sufficient. Higher values have little effect on smoothing. For further details see VTK vtkWindowedSincPolyDataFilter documentation."
           },
           "passband": {
-            "title": "Passband",
             "default": 0.01,
+            "title": "Passband",
             "type": "number",
             "description": "float in range [0,2] that specifies the PassBand for the windowed sinc filter in vtkWindowedSincPolyDataFilter during mesh smoothing. Lower passband values produce more smoothing, due to filtering of higher frequencies. For further details see VTK vtkWindowedSincPolyDataFilter documentation."
           },
           "feature_angle": {
-            "title": "Feature Angle",
             "default": 160,
+            "title": "Feature Angle",
             "type": "integer",
             "description": "int in range [0,180] that specifies the feature angle for sharp edge identification used for vtk FeatureEdgeSmoothing. Higher values result in more smoothened edges in mesh. For further details see VTK vtkWindowedSincPolyDataFilter documentation."
           },
           "target_reduction": {
-            "title": "Target Reduction",
             "default": 0.98,
+            "title": "Target Reduction",
             "type": "number",
             "description": "float in range [0,1]. Target reduction is used during mesh decimation via vtkQuadricDecimation to reduce the number of triangles in a triangle mesh, forming a good approximation to the original geometry. Values closer to 1 indicate larger reduction and smaller mesh file size. Note that target_reduction is expressed as the fraction of the original number of triangles in mesh and so is proportional to original mesh size. Note the actual reduction may be less depending on triangulation and topological constraints. For further details see VTK vtkQuadricDecimation documentation."
           },
           "smoothing_iterations": {
-            "title": "Smoothing Iterations",
             "default": 1,
+            "title": "Smoothing Iterations",
             "type": "integer",
             "description": "the number of iterations that mesh smoothing and decimation is run. If smoothing_iterations > 1, the decimated result is used as input for subsequent smoothing rounds. Recommended to start with 1 iteration and increase if resulting smoothing is insufficient. For each iteration after the first, the passband is reduced and feature_angle is increased incrementally to enhance smoothing. Specifically, the passband is reduced by factor 1/(2^n), and the feature_angle is increased by an increment of (5 * n), where n = iteration round (n=0 is the first iteration). The target_reduction is fixed to 0.1 smoothing_iterations > 1. For example if user inputs (0.01, 160, 0.98) for (passband, feature_angle, target_reduction), the second iteration will use parameters (0.005, 165, 0.1), the third (0.0025, 170, 0.1), etc. Maximum feature_angle is capped at 180. Note that additional iterations usually do not significantly add to processing time as the number of mesh verteces is typically significantly reduced after the first decimation iteration."
           },
           "save_labels": {
-            "title": "Save Labels",
             "default": true,
+            "title": "Save Labels",
             "type": "boolean",
             "description": "if True, saves the calculated 3D label map as label map in 'labels' with suffix '_3d'"
           }
@@ -592,26 +610,8 @@
           "zarr_url",
           "init_args"
         ],
-        "additionalProperties": false,
-        "definitions": {
-          "InitArgsRegistrationConsensus": {
-            "title": "InitArgsRegistrationConsensus",
-            "description": "Registration consensus init args.",
-            "type": "object",
-            "properties": {
-              "zarr_url_list": {
-                "title": "Zarr Url List",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": [
-              "zarr_url_list"
-            ]
-          }
-        }
+        "type": "object",
+        "title": "SurfaceMeshMultiscale"
       },
       "docs_info": "## _init_group_by_well_for_multiplexing\nFinds images for all acquisitions per well.\n\nReturns the parallelization_list to run `find_registration_consensus`.\n## surface_mesh_multiscale\nCalculate 3D surface mesh of parent object (e.g. tissue, organoid)\nfrom 3D cell-level segmentation of children (e.g. nuclei)\n\nRecommended to run on child objects that have been filtered to remove debris and disconnected components\n(e.g. following cleanup_3d_segmentation task)\n\nThis task consists of 4 parts:\n\n1. Load the sub-object (e.g. nuc) segmentation images for each object of a given reference round; skip other rounds.\n    Select sub-objects (e.g. nuc) that belong to parent object region by masking by parent.\n2. Perform label fusion and edge detection to generate surface label image.\n3. Calculate surface mesh of label image using vtkDiscreteFlyingEdges3D algorithm. Smoothing is applied with\n    vtkWindowedSincPolyDataFilter and tuned with 4 task parameters: passband, smoothing_iterations, feature_angle,\n    polynomial_degree (minimal effect).\n    The number of triangles in the mesh is optionally reduced with vtkQuadricDecimation filter to form a good\n    approximation to the original geometry and is tuned with task parameter target_reduction.\n4. Output: save the (1) meshes (.stl) per object id in meshes folder and (2) well label map as a new label in zarr.\n    Note that label map output may be clipped for objects that are dense and have overlapping pixels.\n    In this case, the 'winning' object in the overlap region is the one with higher label id.\n"
     },
@@ -628,15 +628,14 @@
         "mem": 16000
       },
       "args_schema_non_parallel": {
-        "title": "InitGroupByWellForMultiplexing",
-        "type": "object",
+        "additionalProperties": false,
         "properties": {
           "zarr_urls": {
-            "title": "Zarr Urls",
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "title": "Zarr Urls",
+            "type": "array",
             "description": "List of paths or urls to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "zarr_dir": {
@@ -645,8 +644,8 @@
             "description": "path of the directory where the new OME-Zarrs will be created. Not used by this task. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "reference_acquisition": {
-            "title": "Reference Acquisition",
             "default": 0,
+            "title": "Reference Acquisition",
             "type": "integer",
             "description": "Which acquisition to register against. Uses the OME-NGFF HCS well metadata acquisition keys to find the reference acquisition."
           }
@@ -655,11 +654,30 @@
           "zarr_urls",
           "zarr_dir"
         ],
-        "additionalProperties": false
+        "type": "object",
+        "title": "InitGroupByWellForMultiplexing"
       },
       "args_schema_parallel": {
-        "title": "SphericalHarmonicsFromLabelimage",
-        "type": "object",
+        "$defs": {
+          "InitArgsRegistrationConsensus": {
+            "description": "Registration consensus init args.",
+            "properties": {
+              "zarr_url_list": {
+                "items": {
+                  "type": "string"
+                },
+                "title": "Zarr Url List",
+                "type": "array"
+              }
+            },
+            "required": [
+              "zarr_url_list"
+            ],
+            "title": "InitArgsRegistrationConsensus",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
         "properties": {
           "zarr_url": {
             "title": "Zarr Url",
@@ -667,37 +685,37 @@
             "description": "Path or url to the individual OME-Zarr image to be processed. Refers to the zarr_url of the reference acquisition. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "init_args": {
-            "$ref": "#/definitions/InitArgsRegistrationConsensus",
-            "title": "Init_Args",
+            "$ref": "#/$defs/InitArgsRegistrationConsensus",
+            "title": "Init Args",
             "description": "Intialization arguments provided by `init_group_by_well_for_multiplexing`. It contains the zarr_url_list listing all the zarr_urls in the same well as the zarr_url of the reference acquisition that are being processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "label_name": {
-            "title": "Label Name",
             "default": "org_3d",
+            "title": "Label Name",
             "type": "string",
             "description": "Label for which spherical harmonics are calculated"
           },
           "roi_table": {
-            "title": "Roi Table",
             "default": "org_ROI_table_3d",
+            "title": "Roi Table",
             "type": "string",
             "description": "Name of the ROI table over which the task loops to calculate the registration. e.g. consensus object table 'org_ROI_table_consensus'"
           },
           "lmax": {
-            "title": "Lmax",
             "default": 2,
+            "title": "Lmax",
             "type": "integer",
             "description": "Maximum degree of the spherical harmonics coefficients"
           },
           "save_mesh": {
-            "title": "Save Mesh",
             "default": true,
+            "title": "Save Mesh",
             "type": "boolean",
             "description": "If True, saves the computed surface mesh (with vtkContourFilter in aics_shparam functions) on disk in subfolder 'meshes'. Filename corresponds to object label id"
           },
           "save_reconstructed_mesh": {
-            "title": "Save Reconstructed Mesh",
             "default": true,
+            "title": "Save Reconstructed Mesh",
             "type": "boolean",
             "description": "If true, reconstruct mesh from spherical harmonics and save as stl in meshes zarr directory. Filename corresponds to object label id"
           }
@@ -706,26 +724,8 @@
           "zarr_url",
           "init_args"
         ],
-        "additionalProperties": false,
-        "definitions": {
-          "InitArgsRegistrationConsensus": {
-            "title": "InitArgsRegistrationConsensus",
-            "description": "Registration consensus init args.",
-            "type": "object",
-            "properties": {
-              "zarr_url_list": {
-                "title": "Zarr Url List",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": [
-              "zarr_url_list"
-            ]
-          }
-        }
+        "type": "object",
+        "title": "SphericalHarmonicsFromLabelimage"
       },
       "docs_info": "## _init_group_by_well_for_multiplexing\nFinds images for all acquisitions per well.\n\nReturns the parallelization_list to run `find_registration_consensus`.\n## spherical_harmonics_from_labelimage\nCalculate spherical harmonics of 3D input label image using aics_shparam.\n\nThis task consists of 6 parts:\n\n1. Load 3D label image based on provided label name and ROI table\n2. Compute 3D mesh with vtkContourFilter using aics_shparam functions\n3. Compute spherical harmonics of mesh using aics_shparam\n4. Compute reconstruction error (mse) of computed harmonics\n5. Optionally generate reconstructed mesh from the calculated harmonics\n6. Output: save the (1) spherical harmonic coefficients and mse error as feature table\n    (2) reconstructed meshes (.stl) per object id in a new meshes folder within zarr structure\n"
     },
@@ -742,15 +742,14 @@
         "mem": 16000
       },
       "args_schema_non_parallel": {
-        "title": "InitGroupByWellForMultiplexing",
-        "type": "object",
+        "additionalProperties": false,
         "properties": {
           "zarr_urls": {
-            "title": "Zarr Urls",
-            "type": "array",
             "items": {
               "type": "string"
             },
+            "title": "Zarr Urls",
+            "type": "array",
             "description": "List of paths or urls to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "zarr_dir": {
@@ -759,8 +758,8 @@
             "description": "path of the directory where the new OME-Zarrs will be created. Not used by this task. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "reference_acquisition": {
-            "title": "Reference Acquisition",
             "default": 0,
+            "title": "Reference Acquisition",
             "type": "integer",
             "description": "Which acquisition to register against. Uses the OME-NGFF HCS well metadata acquisition keys to find the reference acquisition."
           }
@@ -769,11 +768,30 @@
           "zarr_urls",
           "zarr_dir"
         ],
-        "additionalProperties": false
+        "type": "object",
+        "title": "InitGroupByWellForMultiplexing"
       },
       "args_schema_parallel": {
-        "title": "ScmultiplexMeshMeasurements",
-        "type": "object",
+        "$defs": {
+          "InitArgsRegistrationConsensus": {
+            "description": "Registration consensus init args.",
+            "properties": {
+              "zarr_url_list": {
+                "items": {
+                  "type": "string"
+                },
+                "title": "Zarr Url List",
+                "type": "array"
+              }
+            },
+            "required": [
+              "zarr_url_list"
+            ],
+            "title": "InitArgsRegistrationConsensus",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
         "properties": {
           "zarr_url": {
             "title": "Zarr Url",
@@ -781,8 +799,8 @@
             "description": "Path or url to the individual OME-Zarr image to be processed. Refers to the zarr_url of the reference acquisition. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "init_args": {
-            "$ref": "#/definitions/InitArgsRegistrationConsensus",
-            "title": "Init_Args",
+            "$ref": "#/$defs/InitArgsRegistrationConsensus",
+            "title": "Init Args",
             "description": "Initialization arguments provided by `init_group_by_well_for_multiplexing`. It contains the zarr_url_list listing all the zarr_urls in the same well as the zarr_url of the reference acquisition that are being processed. (standard argument for Fractal tasks, managed by Fractal server)."
           },
           "mesh_name": {
@@ -801,38 +819,38 @@
             "description": "Name of the output AnnData table to save the measurements in. A table of this name can't exist yet in the OME-Zarr file"
           },
           "save_hulls": {
-            "title": "Save Hulls",
             "default": true,
+            "title": "Save Hulls",
             "type": "boolean",
             "description": "if True, save the calculated convex hull and bounding box as .vtp meshes within meshes/[mesh_name]_convex_hull and meshes/[mesh_name]_bounding_box directories"
           },
           "calculate_curvature": {
-            "title": "Calculate Curvature",
             "default": true,
+            "title": "Calculate Curvature",
             "type": "boolean",
             "description": "if True, calculate Gaussian curvature at each mesh point and save as .vtp mesh on disk within meshes/[mesh_name]_curvature folder in zarr structure. Filename corresponds to object label id."
           },
           "calculate_harmonics": {
-            "title": "Calculate Harmonics",
             "default": true,
+            "title": "Calculate Harmonics",
             "type": "boolean",
             "description": "if True, calculate spherical harmonics of mesh using aics_shparam"
           },
           "lmax": {
-            "title": "Lmax",
             "default": 2,
+            "title": "Lmax",
             "type": "integer",
             "description": "Maximum degree of the spherical harmonics coefficients"
           },
           "translate_to_origin": {
-            "title": "Translate To Origin",
             "default": true,
+            "title": "Translate To Origin",
             "type": "boolean",
             "description": "If true, translate centroid of mesh to origin prior to spherical harmonic decomposition. Recommended set to True"
           },
           "save_reconstructed_mesh": {
-            "title": "Save Reconstructed Mesh",
             "default": true,
+            "title": "Save Reconstructed Mesh",
             "type": "boolean",
             "description": "If true, reconstruct mesh from spherical harmonics and save as stl in meshes zarr directory"
           }
@@ -844,26 +862,8 @@
           "roi_table",
           "output_table_name"
         ],
-        "additionalProperties": false,
-        "definitions": {
-          "InitArgsRegistrationConsensus": {
-            "title": "InitArgsRegistrationConsensus",
-            "description": "Registration consensus init args.",
-            "type": "object",
-            "properties": {
-              "zarr_url_list": {
-                "title": "Zarr Url List",
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": [
-              "zarr_url_list"
-            ]
-          }
-        }
+        "type": "object",
+        "title": "ScmultiplexMeshMeasurements"
       },
       "docs_info": "## _init_group_by_well_for_multiplexing\nFinds images for all acquisitions per well.\n\nReturns the parallelization_list to run `find_registration_consensus`.\n## scmultiplex_mesh_measurements\nExtract shape features of 3D input meshes.\n\nThis task consists of 5 parts:\n\n1. Load meshes (.stl) from zarr structure that have been previously generated\n    (e.g. using Surface Mesh Multiscale task)\n2. Extract mesh morphology measurements: volume, surface area, extent, solidity, concavity, asymmetry,\n    aspect ratio, and normalized surface area to volume ratio. Units correspond to units of mesh. If mesh was\n    generated with surface_mesh_multiscale task, units are physical units (um). For further details of features see\n    scMultiplex FeatureFunctions.py\n3. Optionally calculate Gaussian curvature at each mesh point (set calculate_curvature = True)\n4. Optionally compute spherical harmonics of mesh using aics_shparam (set calculate_harmonics = True).\n    Compute reconstruction error (mse) of computed harmonics and optionally generate reconstructed mesh from the\n    calculated harmonics\n5. Output: save (1) extracted measurements as a new table (output_table_name), (2) optional spherical harmonic\n    coefficients and mse error as a separate feature table ('output_table_name'_harmonics) (3) optional\n    reconstructed meshes from spherical harmonics as .stl within zarr structure (3) optional convex hull\n    and bounding box on disk as .vtp within zarr structure (4) optional curvature meshes on disk as .vtp within\n    zarr structure.\n"
     },
@@ -875,8 +875,26 @@
         "mem": 16000
       },
       "args_schema_parallel": {
-        "title": "ScmultiplexFeatureMeasurements",
-        "type": "object",
+        "$defs": {
+          "ChannelInputModel": {
+            "description": "A channel which is specified by either `wavelength_id` or `label`.",
+            "properties": {
+              "wavelength_id": {
+                "title": "Wavelength Id",
+                "type": "string",
+                "description": "Unique ID for the channel wavelength, e.g. `A01_C01`. Can only be specified if label is not set."
+              },
+              "label": {
+                "title": "Label",
+                "type": "string",
+                "description": "Name of the channel. Can only be specified if wavelength_id is not set."
+              }
+            },
+            "title": "ChannelInputModel",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
         "properties": {
           "zarr_url": {
             "title": "Zarr Url",
@@ -894,46 +912,46 @@
             "description": "Name of the output AnnData table to save the measurements in. A table of this name can't exist yet in the OME-Zarr file"
           },
           "input_channels": {
+            "additionalProperties": {
+              "$ref": "#/$defs/ChannelInputModel"
+            },
             "title": "Input Channels",
             "type": "object",
-            "additionalProperties": {
-              "$ref": "#/definitions/ChannelInputModel"
-            },
             "description": "Dictionary of channels to measure. Keys are the names that will be added as prefixes to the measurements, values are another dictionary containing either wavelength_id or channel_label information to allow Fractal to find the correct channel (but not both). Example: {\"C01\": {\"wavelength_id\": \"A01_C01\"}. To only measure morphology, provide an empty dict"
           },
           "input_ROI_table": {
-            "title": "Input Roi Table",
             "default": "well_ROI_table",
+            "title": "Input Roi Table",
             "type": "string",
             "description": "Name of the ROI table to loop over. Needs to exists as a ROI table in the OME-Zarr file"
           },
           "level": {
-            "title": "Level",
             "default": 0,
+            "title": "Level",
             "type": "integer",
             "description": "Resolution of the intensity image to load for measurements. Only tested for level 0"
           },
           "label_level": {
-            "title": "Label Level",
             "default": 0,
+            "title": "Label Level",
             "type": "integer",
             "description": "Resolution of the label image to load for measurements."
           },
           "measure_morphology": {
-            "title": "Measure Morphology",
             "default": true,
+            "title": "Measure Morphology",
             "type": "boolean",
             "description": "Set to True to measure morphology features"
           },
           "allow_duplicate_labels": {
-            "title": "Allow Duplicate Labels",
             "default": false,
+            "title": "Allow Duplicate Labels",
             "type": "boolean",
             "description": "Set to True to allow saving measurement tables with non-unique label values. Can happen when segmentation is run on a different ROI than the measurements (e.g. segment per well, but measure per FOV)"
           },
           "overwrite": {
-            "title": "Overwrite",
             "default": true,
+            "title": "Overwrite",
             "type": "boolean",
             "description": "If `True`, overwrite the task output."
           }
@@ -943,30 +961,12 @@
           "label_image",
           "output_table_name"
         ],
-        "additionalProperties": false,
-        "definitions": {
-          "ChannelInputModel": {
-            "title": "ChannelInputModel",
-            "description": "A channel which is specified by either `wavelength_id` or `label`.",
-            "type": "object",
-            "properties": {
-              "wavelength_id": {
-                "title": "Wavelength Id",
-                "type": "string",
-                "description": "Unique ID for the channel wavelength, e.g. `A01_C01`."
-              },
-              "label": {
-                "title": "Label",
-                "type": "string",
-                "description": "Name of the channel."
-              }
-            }
-          }
-        }
+        "type": "object",
+        "title": "ScmultiplexFeatureMeasurements"
       },
       "docs_info": "## scmultiplex_feature_measurements\nMeasurements of intensities and morphologies\n\nWrapper task for scmultiplex measurements for Fractal to generate\nmeasurements of intensities and morphologies\n"
     }
   ],
   "has_args_schemas": true,
-  "args_schema_version": "pydantic_v1"
+  "args_schema_version": "pydantic_v2"
 }

--- a/src/scmultiplex/features/FeatureFunctions.py
+++ b/src/scmultiplex/features/FeatureFunctions.py
@@ -127,7 +127,7 @@ def minor_major_axis_ratio(prop):
     """Return the ratio of major to minor axis
     """
     if prop.major_axis_length == 0:
-        return np.float('NaN')
+        return np.float64('NaN')
     else:
         return prop.minor_axis_length / prop.major_axis_length
 

--- a/src/scmultiplex/fractal/_image_based_registration_hcs_allrounds_init.py
+++ b/src/scmultiplex/fractal/_image_based_registration_hcs_allrounds_init.py
@@ -16,16 +16,13 @@ with reference round specified in init args.
 import logging
 from typing import Any
 
-from pydantic.decorator import validate_arguments
-
-from fractal_tasks_core.tasks._registration_utils import (
-    create_well_acquisition_dict,
-)
+from fractal_tasks_core.tasks._registration_utils import create_well_acquisition_dict
+from pydantic import validate_call
 
 logger = logging.getLogger(__name__)
 
 
-@validate_arguments
+@validate_call
 def _image_based_registration_hcs_allrounds_init(
     *,
     # Fractal parameters
@@ -54,9 +51,7 @@ def _image_based_registration_hcs_allrounds_init(
         task_output: Dictionary for Fractal server that contains a
             parallelization list.
     """
-    logger.info(
-        f"Running `image_based_registration_hcs_init` for {zarr_urls=}"
-    )
+    logger.info(f"Running `image_based_registration_hcs_init` for {zarr_urls=}")
     image_groups = create_well_acquisition_dict(zarr_urls)
 
     # Create the parallelization list

--- a/src/scmultiplex/fractal/_image_based_registration_hcs_allrounds_init.py
+++ b/src/scmultiplex/fractal/_image_based_registration_hcs_allrounds_init.py
@@ -16,7 +16,7 @@ with reference round specified in init args.
 import logging
 from typing import Any
 
-from fractal_tasks_core.tasks._registration_utils import create_well_acquisition_dict
+from fractal_tasks_core.utils import create_well_acquisition_dict
 from pydantic import validate_call
 
 logger = logging.getLogger(__name__)

--- a/src/scmultiplex/fractal/_image_based_registration_hcs_init.py
+++ b/src/scmultiplex/fractal/_image_based_registration_hcs_init.py
@@ -15,14 +15,15 @@ Initializes the parallelization list for registration in HCS plates.
 import logging
 from typing import Any
 
-from pydantic.decorator import validate_arguments
-
-from fractal_tasks_core.tasks.image_based_registration_hcs_init import image_based_registration_hcs_init
+from fractal_tasks_core.tasks.image_based_registration_hcs_init import (
+    image_based_registration_hcs_init,
+)
+from pydantic import validate_call
 
 logger = logging.getLogger(__name__)
 
 
-@validate_arguments
+@validate_call
 def _image_based_registration_hcs_init(
     *,
     # Fractal parameters
@@ -60,9 +61,11 @@ def _image_based_registration_hcs_init(
 
     # zarr url is the cycle x image, will have a list of non-reference rounds
     # in init args you have the reference zarr url
-    return image_based_registration_hcs_init(zarr_urls=zarr_urls,
-                                             zarr_dir=zarr_dir,
-                                             reference_acquisition=reference_acquisition)
+    return image_based_registration_hcs_init(
+        zarr_urls=zarr_urls,
+        zarr_dir=zarr_dir,
+        reference_acquisition=reference_acquisition,
+    )
 
 
 if __name__ == "__main__":

--- a/src/scmultiplex/fractal/_init_group_by_well_for_multiplexing.py
+++ b/src/scmultiplex/fractal/_init_group_by_well_for_multiplexing.py
@@ -14,14 +14,15 @@ Applies the multiplexing translation to all ROI tables
 """
 import logging
 
-from fractal_tasks_core.tasks.init_group_by_well_for_multiplexing import init_group_by_well_for_multiplexing
-from pydantic.decorator import validate_arguments
-
+from fractal_tasks_core.tasks.init_group_by_well_for_multiplexing import (
+    init_group_by_well_for_multiplexing,
+)
+from pydantic import validate_call
 
 logger = logging.getLogger(__name__)
 
 
-@validate_arguments
+@validate_call
 def _init_group_by_well_for_multiplexing(
     *,
     # Fractal parameters
@@ -49,9 +50,11 @@ def _init_group_by_well_for_multiplexing(
 
     # reference round is given as zarr url, single round for the zarr_url
     # all rounds are given as init_args
-    return init_group_by_well_for_multiplexing(zarr_urls=zarr_urls,
-                                               zarr_dir=zarr_dir,
-                                               reference_acquisition=reference_acquisition)
+    return init_group_by_well_for_multiplexing(
+        zarr_urls=zarr_urls,
+        zarr_dir=zarr_dir,
+        reference_acquisition=reference_acquisition,
+    )
 
 
 if __name__ == "__main__":

--- a/src/scmultiplex/fractal/cleanup_3d_cell_segmentation.py
+++ b/src/scmultiplex/fractal/cleanup_3d_cell_segmentation.py
@@ -9,59 +9,56 @@
 Clean up 3D cell-level segmentation (e.g. nuclei, cells) by size filtering
 and disconnected component analysis
 """
+import logging
+import os
 from pathlib import Path
-from typing import Any
-from typing import Sequence
+from typing import Any, Sequence
 
 import anndata as ad
 import dask.array as da
-import logging
 import numpy as np
-import os
 import pandas as pd
-
 import zarr
 from fractal_tasks_core.labels import prepare_label_group
-from fractal_tasks_core.pyramids import build_pyramid
-from fractal_tasks_core.upscale_array import upscale_array
-from pydantic.decorator import validate_arguments
-
 from fractal_tasks_core.ngff import load_NgffImageMeta
+from fractal_tasks_core.pyramids import build_pyramid
 from fractal_tasks_core.roi import (
     check_valid_ROI_indices,
     convert_indices_to_regions,
     convert_ROI_table_to_indices,
-    load_region)
-
-from skimage.measure import label, regionprops_table
+    load_region,
+)
+from pydantic import validate_call
+from skimage.measure import regionprops_table
 
 from scmultiplex.fractal.fractal_helper_functions import get_zattrs
 from scmultiplex.linking.NucleiLinkingFunctions import remove_labels
-
-from scmultiplex.meshing.FilterFunctions import filter_small_sizes_per_round, mask_by_parent_object
+from scmultiplex.meshing.FilterFunctions import (
+    filter_small_sizes_per_round,
+    mask_by_parent_object,
+)
 
 logger = logging.getLogger(__name__)
 
 
-@validate_arguments
+@validate_call
 def cleanup_3d_cell_segmentation(
-        *,
-        # Fractal arguments
-        input_paths: Sequence[str],
-        output_path: str,
-        component: str,
-        metadata: dict[str, Any],
-        # Task-specific arguments
-        label_name_toclean: str = "nuc",
-        roi_table_toclean: str = "nuc_ROI_table",
-        label_name_parent: str = "org_linked",
-        roi_table_parent: str = "org_ROI_table_linked",
-        level: int = 0,
-        volume_filter_threshold: float = 0.05,
-        mask_by_parent: bool = True,
-        volume_filter: bool = True,
-        disconnected_component_filter: bool = True,
-
+    *,
+    # Fractal arguments
+    input_paths: Sequence[str],
+    output_path: str,
+    component: str,
+    metadata: dict[str, Any],
+    # Task-specific arguments
+    label_name_toclean: str = "nuc",
+    roi_table_toclean: str = "nuc_ROI_table",
+    label_name_parent: str = "org_linked",
+    roi_table_parent: str = "org_ROI_table_linked",
+    level: int = 0,
+    volume_filter_threshold: float = 0.05,
+    mask_by_parent: bool = True,
+    volume_filter: bool = True,
+    disconnected_component_filter: bool = True,
 ) -> dict[str, Any]:
     """
     Calculate 3D surface mesh of parent object (e.g. tissue, organoid)
@@ -130,27 +127,31 @@ def cleanup_3d_cell_segmentation(
     parent_roi_path = f"{input_zarr_path}/tables/{roi_table_parent}"
 
     if not os.path.exists(seg_label_path):
-        logger.warning(f"Segmentation with label name {label_name_toclean} does not exist in round {current_cycle} "
-                       f"of zarr {input_zarr_path} \n"
-                       f"Skipping round {current_cycle}")
+        logger.warning(
+            f"Segmentation with label name {label_name_toclean} does not exist in round {current_cycle} "
+            f"of zarr {input_zarr_path} \n"
+            f"Skipping round {current_cycle}"
+        )
         return {}
 
     if os.path.exists(seg_label_path) and not os.path.exists(seg_roi_path):
-        logger.warning(f"Roi table with name {roi_table_toclean} does not exist in round {current_cycle} for "
-                       f"segmentation with label name {label_name_toclean} of zarr {input_zarr_path} \n"
-                       f"Skipping round {current_cycle}")
+        logger.warning(
+            f"Roi table with name {roi_table_toclean} does not exist in round {current_cycle} for "
+            f"segmentation with label name {label_name_toclean} of zarr {input_zarr_path} \n"
+            f"Skipping round {current_cycle}"
+        )
         return {}
 
     # Lazily load well image to clean as dask array e.g. for nuclear segmentation, and read ROIs
     logger.info(f"Clean cell segmentation is running for cycle {current_cycle}")
     seg_dask = da.from_zarr(seg_label_path)
-    seg_adata = ad.read_zarr(seg_roi_path)
+    # FIXME: Can this be removed? It's not used
+    # seg_adata = ad.read_zarr(seg_roi_path)
     parent_adata = ad.read_zarr(parent_roi_path)
-
 
     # Read Zarr metadata
     seg_ngffmeta = load_NgffImageMeta(f"{input_zarr_path}/labels/{label_name_toclean}")
-    seg_xycoars = seg_ngffmeta.coarsening_xy # need to know when building new pyramids
+    seg_xycoars = seg_ngffmeta.coarsening_xy  # need to know when building new pyramids
     seg_pixmeta = seg_ngffmeta.get_pixel_sizes_zyx(level=level)
 
     # Create list of indices for 3D ROIs spanning the entire Z direction
@@ -175,12 +176,13 @@ def cleanup_3d_cell_segmentation(
     shape = seg_dask.shape
     chunks = seg_dask.chunksize
     label_dtype = np.uint32
-    output_label_name = label_name_toclean + '_clean'
-    output_roi_table_name = roi_table_toclean + '_clean'
+    output_label_name = label_name_toclean + "_clean"
+    # FIXME: Can this be removed? It's not used
+    # output_roi_table_name = roi_table_toclean + "_clean"
     store = zarr.storage.FSStore(f"{input_zarr_path}/labels/{output_label_name}/0")
 
     if len(shape) != 3 or len(chunks) != 3 or shape[0] == 1:
-        raise ValueError('Expecting 3D image')
+        raise ValueError("Expecting 3D image")
 
     # Add metadata to labels group
     # Get the label_attrs correctly
@@ -213,7 +215,9 @@ def cleanup_3d_cell_segmentation(
     parent_dask = da.from_zarr(parent_label_path)
 
     # Read Zarr metadata
-    parent_ngffmeta = load_NgffImageMeta(f"{input_zarr_path}/labels/{label_name_parent}")
+    parent_ngffmeta = load_NgffImageMeta(
+        f"{input_zarr_path}/labels/{label_name_parent}"
+    )
     parent_xycoars = parent_ngffmeta.coarsening_xy
     parent_pixmeta = parent_ngffmeta.get_pixel_sizes_zyx(level=level)
 
@@ -227,9 +231,9 @@ def cleanup_3d_cell_segmentation(
     check_valid_ROI_indices(parent_idlist_parentmeta, roi_table_parent)
 
     # initialize variables
-    parent_labels = parent_adata.obs_vector('label')
+    parent_labels = parent_adata.obs_vector("label")
     compute = True  # convert to numpy array from dask
-    segids_toremove_perwell = [] # list of nuclei ids to remove in the well
+    segids_toremove_perwell = []  # list of nuclei ids to remove in the well
 
     ##############
     # Perform cleanup per object ###
@@ -252,7 +256,9 @@ def cleanup_3d_cell_segmentation(
         )
 
         # mask by parent to only analyze nuclei belonging to the given organoid
-        seg = mask_by_parent_object(seg, parent_dask, parent_idlist_parentmeta, row_int, parent_label_id)
+        seg = mask_by_parent_object(
+            seg, parent_dask, parent_idlist_parentmeta, row_int, parent_label_id
+        )
 
         # run regionprops to extract centroids and volume of each nuc label
         # note that all cleanup steps is performed on unscaled image which may have strong z-anisotropy
@@ -261,32 +267,50 @@ def cleanup_3d_cell_segmentation(
 
         if volume_filter:
 
-            seg_props = regionprops_table(label_image=seg, properties=('label', 'centroid', 'area'))  # zyx
+            seg_props = regionprops_table(
+                label_image=seg, properties=("label", "centroid", "area")
+            )  # zyx
 
             # output column order must be: ["label", "x_centroid", "y_centroid", "z_centroid", "volume"]
             # units are in pixels
-            seg_props = (pd.DataFrame(seg_props,
-                                     columns=['label', 'centroid-2', 'centroid-1', 'centroid-0', 'area'])).to_numpy()
+            seg_props = (
+                pd.DataFrame(
+                    seg_props,
+                    columns=["label", "centroid-2", "centroid-1", "centroid-0", "area"],
+                )
+            ).to_numpy()
 
             # discard segmentations that have a volume less than fraction of median nuclear volume (segmented debris)
-            (seg_props, remove_volumefilter, removed_size_mean, size_mean, volume_cutoff) = (
-                filter_small_sizes_per_round(seg_props, column=-1, threshold=volume_filter_threshold))
+            (
+                seg_props,
+                remove_volumefilter,
+                removed_size_mean,
+                size_mean,
+                volume_cutoff,
+            ) = filter_small_sizes_per_round(
+                seg_props, column=-1, threshold=volume_filter_threshold
+            )
 
-            logger.info(f"Performing volume filtering of object {parent_label_id} to "
-                        f"remove small debris below {volume_cutoff} pix threshold")
+            logger.info(
+                f"Performing volume filtering of object {parent_label_id} to "
+                f"remove small debris below {volume_cutoff} pix threshold"
+            )
 
-            logger.info(f"Filtered out {len(remove_volumefilter)} cells from object {parent_label_id} that have a "
-                        f" mean volume of {removed_size_mean} and correspond to labels \n {remove_volumefilter}"
-                       )
+            logger.info(
+                f"Filtered out {len(remove_volumefilter)} cells from object {parent_label_id} that have a "
+                f" mean volume of {removed_size_mean} and correspond to labels \n {remove_volumefilter}"
+            )
 
-            remove_volumefilter = list(remove_volumefilter) # list of float64
+            remove_volumefilter = list(remove_volumefilter)  # list of float64
 
             segids_toremove.extend(remove_volumefilter)
 
         if disconnected_component_filter:
-            logger.info(f"Performing disconnected component filtering of object {parent_label_id} "
-                        f"to remove clusters outside of main object")
-            #TODO
+            logger.info(
+                f"Performing disconnected component filtering of object {parent_label_id} "
+                f"to remove clusters outside of main object"
+            )
+            # TODO
             remove_disconnected = []
             segids_toremove.extend(remove_disconnected)
 
@@ -305,7 +329,9 @@ def cleanup_3d_cell_segmentation(
         # store labels as new label map in zarr
 
         # load dask from disk, will contain rois of the previously processed objects within for loop
-        new_label3d_dask = da.from_zarr(f"{input_zarr_path}/labels/{output_label_name}/0")
+        new_label3d_dask = da.from_zarr(
+            f"{input_zarr_path}/labels/{output_label_name}/0"
+        )
         # load region of current object from disk, will include any previously processed neighboring objects
         seg_ondisk = load_region(
             data_zyx=new_label3d_dask,
@@ -315,7 +341,9 @@ def cleanup_3d_cell_segmentation(
 
         # check that dimensions of rois match
         if seg_ondisk.shape != seg_filtered.shape:
-            raise ValueError('Filtered label image must match image dimensions of bounding box during saving')
+            raise ValueError(
+                "Filtered label image must match image dimensions of bounding box during saving"
+            )
 
         # use fmax so that if one of the elements being compared is a NaN, then the non-nan element is returned
         seg_filtered_tosave = np.fmax(seg_filtered, seg_ondisk)
@@ -339,11 +367,15 @@ def cleanup_3d_cell_segmentation(
         aggregation_function=np.max,
     )
 
-    logger.info(f"Built a pyramid for the {input_zarr_path}/labels/{output_label_name} label image")
+    logger.info(
+        f"Built a pyramid for the {input_zarr_path}/labels/{output_label_name} label image"
+    )
 
     # Filter ROI table
     # print('fullwell', segids_toremove_perwell)
-    logger.info(f"End clean cell segmentation task for {input_zarr_path}/labels/{output_label_name}")
+    logger.info(
+        f"End clean cell segmentation task for {input_zarr_path}/labels/{output_label_name}"
+    )
 
     return {}
 

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -34,7 +34,7 @@ from fractal_tasks_core.roi import (
 )
 from fractal_tasks_core.tables import write_table
 from fractal_tasks_core.upscale_array import upscale_array
-from pydantic.decorator import validate_arguments
+from pydantic import validate_call
 
 from scmultiplex.features.feature_wrapper import get_regionprops_measurements
 
@@ -44,7 +44,7 @@ __OME_NGFF_VERSION__ = fractal_tasks_core.__OME_NGFF_VERSION__
 logger = logging.getLogger(__name__)
 
 
-@validate_arguments
+@validate_call
 def scmultiplex_feature_measurements(  # noqa: C901
     *,
     # Default arguments for fractal tasks:

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -13,7 +13,7 @@ Wrapper of scMultipleX measurements for Fractal
 """
 
 import logging
-from typing import Dict
+from typing import Dict, Union
 
 import anndata as ad
 import dask.array as da
@@ -52,7 +52,7 @@ def scmultiplex_feature_measurements(  # noqa: C901
     # Task-specific arguments:
     label_image: str,
     output_table_name: str,
-    input_channels: Dict[str, ChannelInputModel] = None,
+    input_channels: Union[Dict[str, ChannelInputModel], None] = None,
     input_ROI_table: str = "well_ROI_table",
     level: int = 0,
     label_level: int = 0,

--- a/src/scmultiplex/fractal/spherical_harmonics_from_labelimage.py
+++ b/src/scmultiplex/fractal/spherical_harmonics_from_labelimage.py
@@ -9,45 +9,45 @@
 Calculate spherical harmonics of 3D input label image using aics_shparam.
 """
 
+import logging
+import os
+from typing import Any
+
 import anndata as ad
 import dask.array as da
-import logging
 import numpy as np
-import os
 import pandas as pd
 import zarr
-
-from fractal_tasks_core.tables import write_table
-from fractal_tasks_core.tasks.io_models import InitArgsRegistrationConsensus
 from fractal_tasks_core.ngff import load_NgffImageMeta
 from fractal_tasks_core.roi import (
     check_valid_ROI_indices,
     convert_indices_to_regions,
     convert_ROI_table_to_indices,
-    load_region)
-from pydantic.decorator import validate_arguments
-from typing import Any
+    load_region,
+)
+from fractal_tasks_core.tables import write_table
+from fractal_tasks_core.tasks.io_models import InitArgsRegistrationConsensus
+from pydantic import validate_call
 
+from scmultiplex.aics_shparam import shparam, shtools
 from scmultiplex.fractal.fractal_helper_functions import format_roi_table
 from scmultiplex.meshing.MeshFunctions import export_stl_polydata
-from scmultiplex.aics_shparam import shparam, shtools
 
 logger = logging.getLogger(__name__)
 
 
-@validate_arguments
+@validate_call
 def spherical_harmonics_from_labelimage(
-        *,
-        # Fractal arguments
-        zarr_url: str,
-        init_args: InitArgsRegistrationConsensus,
-        # Task-specific arguments
-        label_name: str = "org_3d",
-        roi_table: str = "org_ROI_table_3d",
-        lmax: int = 2,
-        save_mesh: bool = True,
-        save_reconstructed_mesh: bool = True,
-
+    *,
+    # Fractal arguments
+    zarr_url: str,
+    init_args: InitArgsRegistrationConsensus,
+    # Task-specific arguments
+    label_name: str = "org_3d",
+    roi_table: str = "org_ROI_table_3d",
+    lmax: int = 2,
+    save_mesh: bool = True,
+    save_reconstructed_mesh: bool = True,
 ) -> dict[str, Any]:
     """
     Calculate spherical harmonics of 3D input label image using aics_shparam.
@@ -109,7 +109,7 @@ def spherical_harmonics_from_labelimage(
 
     check_valid_ROI_indices(idlist, roi_table)
 
-    labels = adata.obs_vector('label')
+    labels = adata.obs_vector("label")
     # initialize variables
     compute = True  # convert to numpy array from dask
 
@@ -140,14 +140,14 @@ def spherical_harmonics_from_labelimage(
         # Set spacing to ome-zarr pixel spacing metadata. Mesh will be in physical units (um)
         spacing = tuple(np.array(pixmeta))  # z,y,x e.g. (0.6, 0.216, 0.216)
 
-        ((coeffs, grid_rec), (image_, mesh, grid_down, transform)) = shparam.get_shcoeffs(image=seg,
-                                                                                          lmax=lmax,
-                                                                                          sigma=5,
-                                                                                          spacing=spacing)
+        (
+            (coeffs, grid_rec),
+            (image_, mesh, grid_down, transform),
+        ) = shparam.get_shcoeffs(image=seg, lmax=lmax, sigma=5, spacing=spacing)
 
         # Calculate reconstruction error
         mse = shtools.get_reconstruction_error(grid_down, grid_rec)
-        coeffs.update({'mse': mse, 'label': org_label})
+        coeffs.update({"mse": mse, "label": org_label})
         df_coeffs.append(coeffs)
 
         logger.info(f"Successfully calculated harmonics for label {org_label}.")
@@ -196,7 +196,7 @@ def spherical_harmonics_from_labelimage(
         "region": {"path": f"../labels/{label_name}"},
         "instance_key": "label",
     }
-    output_table_name = label_name + '_harmonics'
+    output_table_name = label_name + "_harmonics"
     write_table(
         image_group,
         output_table_name,

--- a/src/scmultiplex/platymatch/platymatch/estimate_transform/apply_transform.py
+++ b/src/scmultiplex/platymatch/platymatch/estimate_transform/apply_transform.py
@@ -25,7 +25,7 @@ def apply_tps_transform(moving_all, moving_cp, w_a_x, w_a_y, w_a_z):
     N = moving_all.shape[0]
     N1 = moving_cp.shape[0] 
     
-    A = np.zeros((N, N1+4), dtype=np.float) # N x (N1+4)
+    A = np.zeros((N, N1+4), dtype=np.float64) # N x (N1+4)
     k = distance_matrix(moving_all, moving_cp) # N x N1
     A[:, :N1] = get_U(k) # N x N1
     A[:, N1:] = m1 # N x 4

--- a/tests/fractal/test_manifest.py
+++ b/tests/fractal/test_manifest.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+
+from fractal_tasks_core.dev.lib_args_schemas import create_schema_for_single_task
+from fractal_tasks_core.dev.lib_signature_constraints import (
+    _extract_function,
+    _validate_function_signature,
+)
+
+import scmultiplex
+
+FRACTAL_TASKS_CORE_DIR = Path(scmultiplex.__file__).parent
+PACKAGE_NAME = "scmultiplex"
+with (FRACTAL_TASKS_CORE_DIR / "__FRACTAL_MANIFEST__.json").open("r") as f:
+    MANIFEST = json.load(f)
+TASK_LIST = MANIFEST["task_list"]
+
+
+def test_task_functions_have_valid_signatures():
+    """
+    Test that task functions have valid signatures.
+    """
+    for task in TASK_LIST:
+        for key in ["executable_non_parallel", "executable_parallel"]:
+            value = task.get(key, None)
+            if value is not None:
+                function_name = Path(task[key]).with_suffix("").name
+                task_function = _extract_function(
+                    task[key], function_name, package_name=PACKAGE_NAME
+                )
+                _validate_function_signature(task_function)
+
+
+def test_args_schemas_are_up_to_date():
+    """
+    Test that args_schema attributes in the manifest are up-to-date
+    """
+    for ind_task, task in enumerate(TASK_LIST):
+        for kind in ["non_parallel", "parallel"]:
+            key = f"executable_{kind}"
+            value = task.get(key, None)
+            if value is not None:
+                print(f"Now handling {task[key]}")
+                old_schema = TASK_LIST[ind_task].get(f"args_schema_{kind}", None)
+                assert old_schema is not None
+                new_schema = create_schema_for_single_task(
+                    task[key], package=PACKAGE_NAME
+                )
+                # The following step is required because some arguments may
+                # have a default which has a non-JSON type (e.g. a tuple),
+                # which we need to convert to JSON type (i.e. an array) before
+                # comparison.
+                new_schema = json.loads(json.dumps(new_schema))
+                assert new_schema == old_schema


### PR DESCRIPTION
Hey @nrepina

This is the updated version of the PR with your changes merged in from main.

I made a PR here to update to the newest version of fractal-tasks-core. The core update concerns using pydanticV2 => different syntax for the fractal task function validation. Due to pre-commit, there are lots of minor changes though in the task functions. They are all just automated syntax updates, not manual changes by me.

Further additions:

- I also added the fix for the numpy floats that should allow us to relax the numpy dependency (I kept it pinned under 2, as I'd expect that there may be additional issues there) => closes #104 
- Fix the import of create_well_acquisition_dict to work with new fractal-tasks-core version => closes #113 
- Very minor syntax fixes by running pre-commit across the task functions. That also found 2 variables that were defined and never used (see FIXME comments). Do you want to keep using pre-commit? Happy to help setting it up in your local dev environment if that's useful for you
- I noticed that the manifest wasn't fully up-to-date. Part of it was just an unexpected ordering of entries (dunno where that came from). I now updated the manifest (makes tests pass on the fractal-tasks-core side, because we also check whether our manifest creation breaks scmultiplex manifests) & added tests to check that the manifest that's on Github is up-to-date with the source code.
- Very minor typing update to the measurement task to ensure not providing any intensity channels to measure still works in pydanticV2 world

The PR would be ready for review from your side. Let me know if any questions come up