### PR TITLE
3D Feature Extraction debugging

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     scikit-learn
     scipy
     tqdm
-    vtk
+    vtk==9.3.1
 python_requires = >=3.8
 package_dir =
     = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ where = src
 [options.extras_require]
 fractal-tasks =
     anndata
-    fractal-tasks-core==1.2.1
+    fractal-tasks-core==1.3.3
 plotting =
     anndata
     dask

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -1175,11 +1175,6 @@
             "type": "string",
             "description": "Name of the ROI table to loop over. Needs to exists as a ROI table in the OME-Zarr file"
           },
-          "masking_label_name": {
-            "title": "Masking Label Name",
-            "type": "string",
-            "description": "Name of label by which to mask label_image."
-          },
           "level": {
             "default": 0,
             "title": "Level",

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -1268,6 +1268,12 @@
             "title": "Expand By Factor",
             "type": "number",
             "description": "Multiplier that specifies pixels by which to expand each label. Float in range [0, 1 or higher], e.g. 0.2 means that 20% of mean equivalent diameter of labels in region is used."
+          },
+          "mask_expansion_by_parent": {
+            "default": false,
+            "title": "Mask Expansion By Parent",
+            "type": "boolean",
+            "description": "If True, final expanded labels are masked by group_by object. Recommended to set to True for child/parent masking."
           }
         },
         "required": [

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -1175,6 +1175,11 @@
             "type": "string",
             "description": "Name of the ROI table to loop over. Needs to exists as a ROI table in the OME-Zarr file"
           },
+          "masking_label_name": {
+            "title": "Masking Label Name",
+            "type": "string",
+            "description": "Name of label by which to mask label_image."
+          },
           "level": {
             "default": 0,
             "title": "Level",

--- a/src/scmultiplex/fractal/expand_labels.py
+++ b/src/scmultiplex/fractal/expand_labels.py
@@ -49,6 +49,7 @@ def expand_labels(
     expand_by_pixels: Union[int, None] = None,
     calculate_image_based_expansion_distance: bool = False,
     expand_by_factor: Union[float, None] = None,
+    mask_expansion_by_parent: bool = False,
 ) -> dict[str, Any]:
     """
     Expand labels in 2D or 3D image without overlap.
@@ -72,6 +73,8 @@ def expand_labels(
             be supplied.
         expand_by_factor: Multiplier that specifies pixels by which to expand each label. Float in range
             [0, 1 or higher], e.g. 0.2 means that 20% of mean equivalent diameter of labels in region is used.
+        mask_expansion_by_parent: If True, final expanded labels are masked by group_by object. Recommended to set
+            to True for child/parent masking.
     """
 
     logger.info(
@@ -243,6 +246,10 @@ def expand_labels(
             expandby,
             expansion_distance_image_based=calculate_image_based_expansion_distance,
         )
+
+        if mask_expansion_by_parent and group_by is not None:
+            seg_expanded = seg_expanded * parent_mask
+
         logger.info(f"Expanded label(s) in region {label_str} by {distance} pixels.")
 
         ##############

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -331,7 +331,7 @@ def scmultiplex_feature_measurements(  # noqa: C901
         df_well = df_well.astype(measurement_dtype)
         df_well.index = df_well.index.map(str)
         # Convert to anndata
-        measurement_table = ad.AnnData(df_well, dtype=measurement_dtype)
+        measurement_table = ad.AnnData(df_well)
         measurement_table.obs = df_info_well
     else:
         # Create empty anndata table

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -202,6 +202,7 @@ def scmultiplex_feature_measurements(  # noqa: C901
     # If relevant, load parent object segmentation to mask child objects
     # TODO: improve handling of case where shape of parent segmentation does not match child segmentation; attempt at
     #  upscaling is implemented in mask_by_parent_object function, but may not cover search-first edge cases
+    # FIXME: Drop masking_label_name
     if use_ROI_masks and masking_label_name is not None:
         # Load well image as dask array for parent objects
         # Metadata for this label image is set by input_ROI_table
@@ -254,6 +255,7 @@ def scmultiplex_feature_measurements(  # noqa: C901
                         f"Calculating features for {label_image} object(s) masked by "
                         f"region label {current_label}"
                     )
+            # FIXME: Drop this else branch, we should never hit it
             else:
                 # This works only in case where masking object is of same parent/child class
                 # as feature extracted object, e.g. organoid mask on organoid features

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -210,6 +210,14 @@ def scmultiplex_feature_measurements(  # noqa: C901
         # Load well image as dask array for parent objects
         mask_dask = da.from_zarr(masking_label_url)
 
+        # Upscale masking image to target resolution
+        mask_dask = upscale_array(
+            array=mask_dask,
+            target_shape=target_shape,
+            axis=axis,
+            pad_with_zeros=True,
+        )
+
     # Loop over ROIs to make measurements
     df_well = pd.DataFrame()
     df_info_well = pd.DataFrame()

--- a/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
+++ b/src/scmultiplex/fractal/scmultiplex_feature_measurements.py
@@ -205,7 +205,7 @@ def scmultiplex_feature_measurements(  # noqa: C901
 
         logger.debug(f"ROI {i_ROI+1}/{num_ROIs}: {region=}")
 
-        # Define some constant values to be added as a separat column to
+        # Define some constant values to be added as a separate column to
         # the obs table
         extra_values = {
             "ROI_table_name": input_ROI_table,
@@ -218,7 +218,7 @@ def scmultiplex_feature_measurements(  # noqa: C901
 
         label_img = input_label_image[region].compute()
         if use_ROI_masks:
-            current_label = int(ROI_table.obs.iloc[i_ROI]["label"])
+            current_label = int(float(ROI_table.obs.iloc[i_ROI]["label"]))
             background = label_img != current_label
             label_img[background] = 0
             extra_values["ROI_label"] = current_label
@@ -239,7 +239,6 @@ def scmultiplex_feature_measurements(  # noqa: C901
                 f"Loaded an image of shape {label_img.shape}. "
                 "Processing is only supported for 2D & 3D images"
             )
-
         # Set inputs
         df_roi = pd.DataFrame()
         df_info_roi = pd.DataFrame()
@@ -273,7 +272,6 @@ def scmultiplex_feature_measurements(  # noqa: C901
                     channel_prefix=input_name,
                     extra_values=extra_values,
                 )
-
                 # Only measure morphology for the first intensity channel provided
                 # => just once per label image
                 first_channel = False

--- a/tests/fractal/conftest.py
+++ b/tests/fractal/conftest.py
@@ -240,7 +240,7 @@ def linking_zenodo_zarrs(testdata_path: Path) -> list[str]:
     """
 
     # 1 Download Zarrs from Zenodo
-    DOI = "10.5281/zenodo.10683086"
+    DOI = "10.5281/zenodo.13982701"
     DOI_slug = DOI.replace("/", "_").replace(".", "_")
     platenames = [
         "220605_151046.zarr",

--- a/tests/fractal/integration/test_fractal_tasks.py
+++ b/tests/fractal/integration/test_fractal_tasks.py
@@ -35,7 +35,7 @@ name_3d = "220605_151046.zarr"
 name_mip = "220605_151046_mip.zarr"
 
 test_calculate_object_linking_expected_output = np.array(
-    [[1.0, 1.0, 0.9305816], [2.0, 2.0, 0.78365386], [3.0, 3.0, 0.95049506]]
+    [[1.0, 1.0, 0.9727956], [2.0, 2.0, 0.8249731], [3.0, 3.0, 0.9644809]]
 )
 
 test_calculate_linking_consensus_expected_output = np.array(
@@ -45,59 +45,60 @@ test_calculate_linking_consensus_expected_output = np.array(
 test_relabel_by_linking_consensus_output_dict = {
     "0": np.array(
         [
-            [13.0, 20.8, 0.0, 22.533333, 21.666666, 0.6],
-            [13.0, 90.13333, 0.0, 20.8, 18.2, 0.6],
-            [38.133335, 103.13333, 0.0, 25.133333, 29.466667, 0.6],
+            [13.216666, 21.016666, 0.0, 22.1, 20.583334, 0.6],
+            [13.866667, 91.433334, 0.0, 18.85, 15.816667, 0.6],
+            [39.0, 103.566666, 0.0, 23.183332, 28.166666, 0.6],
         ]
     ),
     "1": np.array(
         [
-            [49.4, 10.4, 0.0, 23.4, 22.533333, 0.6],
-            [51.133335, 81.46667, 0.0, 19.933332, 16.466667, 0.6],
-            [74.53333, 92.73333, 0.0, 24.266666, 29.466667, 0.6],
+            [49.616665, 11.05, 0.0, 22.533333, 20.583334, 0.6],
+            [51.783333, 81.9, 0.0, 18.85, 15.816667, 0.6],
+            [75.4, 93.816666, 0.0, 23.4, 27.95, 0.6],
         ]
     ),
 }
+
 test_calculate_platymatch_registration_output = np.array(
     [
         [1.0, 1.0],
-        [3.0, 2.0],
-        [2.0, 3.0],
+        [2.0, 2.0],
+        [3.0, 3.0],
         [4.0, 4.0],
-        [5.0, 5.0],
-        [6.0, 6.0],
-        [7.0, 7.0],
-        [8.0, 8.0],
-        [9.0, 9.0],
-        [10.0, 10.0],
-        [11.0, 11.0],
-        [12.0, 12.0],
-        [13.0, 13.0],
-        [14.0, 14.0],
-        [15.0, 15.0],
-        [16.0, 16.0],
+        [8.0, 7.0],
+        [9.0, 8.0],
+        [10.0, 9.0],
+        [11.0, 10.0],
+        [13.0, 12.0],
+        [14.0, 13.0],
+        [15.0, 14.0],
+        [16.0, 15.0],
+        [17.0, 16.0],
+        [19.0, 17.0],
+        [18.0, 18.0],
+        [20.0, 19.0],
     ]
 )
 
 test_sphr_harmonics_from_labelimg_expected_output = np.array(
-    [10.87666, 9.29089, 13.33493]
+    [10.86649, 9.2556, 13.3412]
 )
 
 test_sphr_harmonics_from_mesh_expected_output = np.array(
-    [10.116642, 8.294999, 12.791296]
+    [10.115658, 8.254395, 12.78826]
 )
 
 test_scmultiplex_mesh_measurements_expected_output = np.array(
     [
-        4.31434180e03,
-        1.30477405e03,
-        1.01806331e00,
-        4.67207789e-01,
-        9.94542837e-01,
-        5.45713631e-03,
-        1.40581485e-02,
-        1.12836015e00,
-        1.00899124e00,
+        4.3092324e03,
+        1.3029731e03,
+        1.0174618e00,
+        4.6224737e-01,
+        9.9401093e-01,
+        5.9890612e-03,
+        9.5799491e-03,
+        1.1295289e00,
+        1.0086931e00,
     ]
 )
 
@@ -142,7 +143,6 @@ def test_calculate_object_linking(linking_zenodo_zarrs, name=name_mip):
         output_table_path = f"{zarr_url}/tables/{label_name}_match_table"
 
         output = ad.read_zarr(output_table_path).to_df().to_numpy()
-
         assert_almost_equal(output, test_calculate_object_linking_expected_output)
 
 
@@ -231,7 +231,7 @@ def test_calculate_platymatch_registration(linking_zenodo_zarrs, name=name_3d):
             calculate_ffd=True,
             seg_channel=channel,
             volume_filter=True,
-            volume_filter_threshold=0.05,
+            volume_filter_threshold=0.10,
         )
 
         output_table_path_affine = (

--- a/tests/fractal/test_fractal_measurement.py
+++ b/tests/fractal/test_fractal_measurement.py
@@ -287,6 +287,45 @@ def test_masked_measurements(
     assert_frame_equal(df, df_expected)
 
 
+@pytest.mark.filterwarnings("ignore:Transforming to str index.")
+def test_masked_measurements_with_orgs_and_nuc(
+    linking_zenodo_zarrs,
+):
+    """
+    The purpose is to test masked measurements where the mask is a different
+    label image than the labels to be measured. See
+    https://github.com/fmi-basel/gliberal-scMultipleX/pull/122 for details.
+    """
+    allow_duplicate_labels = False
+    zarr_url = f"{linking_zenodo_zarrs[0]}/C/02/0"
+    input_ROI_table = "org_ROI_table"
+    measure_morphology = True
+    output_table_name = "measurements_nuc_masked"
+    input_channels = {"C01": ChannelInputModel(wavelength_id="A04_C01")}
+
+    # Prepare fractal task
+    label_image = "nuc"
+
+    scmultiplex_feature_measurements(
+        zarr_url=zarr_url,
+        input_ROI_table=input_ROI_table,
+        input_channels=input_channels,
+        label_image=label_image,
+        label_level=label_level,
+        level=level,
+        output_table_name=output_table_name,
+        measure_morphology=measure_morphology,
+        allow_duplicate_labels=allow_duplicate_labels,
+    )
+
+    # Check that there are measurement for all 20 nuclei (before #122,
+    # there was only 1 measurements)
+    # Check & verify the output_table
+    ad_path = Path(zarr_url) / "tables" / output_table_name
+    df = load_features_for_well(ad_path)
+    assert len(df) == 20
+
+
 inputs_empty = [
     ({}, True),
     ({}, False),

--- a/tests/fractal/test_fractal_measurement.py
+++ b/tests/fractal/test_fractal_measurement.py
@@ -226,16 +226,20 @@ def test_3D_fractal_measurements(
 
 
 inputs_masked = [{}, single_input_channels]
+inputs_masked = [single_input_channels]
 
 
 @pytest.mark.filterwarnings("ignore:Transforming to str index.")
 @pytest.mark.parametrize("input_channels,", inputs_masked)
-def test_masked_measurements(
+def test_masked_measurements_test(
     tiny_zenodo_zarrs_base_path,
     metadata_tiny_zenodo,
     column_names,
     input_channels,
 ):
+    # FIXME: Get a smaller test dataset to test this on. This test takes ~40s.
+    # Criteria: Has masking ROI table, resolution of label image != resolution
+    # of intensity image.
     # Test measuring when using a ROI table with masks
     allow_duplicate_labels = False
     zarr_url = f"{tiny_zenodo_zarrs_base_path}/{image_path_2D}"


### PR DESCRIPTION
This PR addresses a few bug fixes in the Feature Extraction task:

- Bug fix in feature extraction to handle child object masking by parent. Previously masking was performed by selecting the label of child object that corresponds to parent object. This approach works for masking of objects of the same child/parent class (e.g. organoids masked by organoids), but results in an empty label image for child/parent relations, except in the rare case that the parent object happens to have the same label as one of the children objects. Proposed fix is to load the parent object segmentation image and mask by the binary image. This solution handles masking for both child/parent relations and objects of the same class, however to reduce code modification and backwards compatibility the previous method was kept in the case that a masking label name is not supplied. Current tests pass, but should be extended to check for the child/parent masking case. @jluethi See TODO notes in task for better handling of edge cases (e.g. upscaling in case of different array shapes)
- Improved logging and check for empty arrays. 
- Fix Anndata dtype deprecation warning.
- Cast current region label to float prior to int conversion to handle ValueError in case of ROI label that is stored as string of float.

@jluethi Please have a look and we can decide on the best approach for these fixes before merging into main. 