### PR TITLE
Add task metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,41 @@ jobs:
 
       - name: Coverage
         uses: codecov/codecov-action@v3
+
+  deploy:
+    name: Deploy
+    needs: test
+    if: success() && startsWith(github.ref, 'refs/tags/') && github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing on PyPi
+      # see https://docs.pypi.org/trusted-publishers/
+      id-token: write
+      # This permission allows writing releases
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: 👷 Build
+        run: |
+          python -m pip install build
+          python -m build
+
+      - name: 🚢 Publish to PyPI
+        # TODO remove the "if: false" line when the package is ready for pypi release
+        if: false
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: './dist/*'

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ The workflow consists of the following tasks:
 
 See scMultipleX GitHub [Wiki](https://github.com/fmi-basel/gliberal-scMultipleX/wiki).
 
+# Making releases
+
+To make new releases, tag a specific commit in main (e.g. with v0.7.10) and push that tag to Github. The CI will take care of making a Github release and pushing it to PyPI.
+```
+git tag v0.7.10
+git push origin v0.7.10
+```
+
 # Contributors and License
 
 Unless otherwise stated in each individual module, all scMultipleX components are released according to a BSD 3-Clause License, and Copyright is with Friedrich Miescher Institute for Biomedical Research.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ where = src
 [options.extras_require]
 fractal-tasks =
     anndata
-    fractal-tasks-core==1.2.1
+    fractal-tasks-core==1.3.3
 plotting =
     anndata
     dask

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -6,7 +6,8 @@
       "category": "Registration",
       "modality": "HCS",
       "tags": [
-        "multiplexing"
+        "multiplexing",
+        "2D"
       ],
       "executable_non_parallel": "fractal/_image_based_registration_hcs_init.py",
       "executable_parallel": "fractal/calculate_object_linking.py",
@@ -116,7 +117,9 @@
       "category": "Registration",
       "modality": "HCS",
       "tags": [
-        "multiplexing"
+        "multiplexing",
+        "2D",
+        "3D"
       ],
       "executable_non_parallel": "fractal/_init_group_by_well_for_multiplexing.py",
       "executable_parallel": "fractal/calculate_linking_consensus.py",
@@ -211,7 +214,9 @@
       "category": "Registration",
       "modality": "HCS",
       "tags": [
-        "multiplexing"
+        "multiplexing",
+        "2D",
+        "3D"
       ],
       "executable_non_parallel": "fractal/_image_based_registration_hcs_allrounds_init.py",
       "executable_parallel": "fractal/relabel_by_linking_consensus.py",
@@ -315,7 +320,8 @@
       "category": "Registration",
       "modality": "HCS",
       "tags": [
-        "multiplexing"
+        "multiplexing",
+        "3D"
       ],
       "executable_non_parallel": "fractal/_image_based_registration_hcs_init.py",
       "executable_parallel": "fractal/calculate_platymatch_registration.py",
@@ -475,7 +481,12 @@
     },
     {
       "name": "scMultiplex Surface Mesh Multiscale",
+      "category": "Image Processing",
       "modality": "HCS",
+      "tags": [
+        "3D",
+        "mesh"
+      ],
       "executable_non_parallel": "fractal/_init_group_by_well_for_multiplexing.py",
       "executable_parallel": "fractal/surface_mesh_multiscale.py",
       "meta_non_parallel": {
@@ -657,6 +668,10 @@
       "name": "scMultiplex Segment by Intensity Threshold",
       "category": "Segmentation",
       "modality": "HCS",
+      "tags": [
+        "Classical segmentation",
+        "3D"
+      ],
       "executable_non_parallel": "fractal/init_select_multiplexing_round.py",
       "executable_parallel": "fractal/segment_by_intensity_threshold.py",
       "meta_non_parallel": {
@@ -892,6 +907,9 @@
       "name": "scMultiplex Spherical Harmonics from Label Image",
       "category": "Measurement",
       "modality": "HCS",
+      "tags": [
+        "3D"
+      ],
       "executable_non_parallel": "fractal/_init_group_by_well_for_multiplexing.py",
       "executable_parallel": "fractal/spherical_harmonics_from_labelimage.py",
       "meta_non_parallel": {
@@ -1008,6 +1026,11 @@
       "name": "scMultiplex Mesh Measurements",
       "category": "Measurement",
       "modality": "HCS",
+      "tags": [
+        "3D",
+        "mesh",
+        "morphology"
+      ],
       "executable_non_parallel": "fractal/_init_group_by_well_for_multiplexing.py",
       "executable_parallel": "fractal/scmultiplex_mesh_measurements.py",
       "meta_non_parallel": {
@@ -1251,6 +1274,10 @@
     },
     {
       "name": "scMultiplex Expand Labels",
+      "tags": [
+        "2D",
+        "3D"
+      ],
       "executable_parallel": "fractal/expand_labels.py",
       "meta_parallel": {
         "cpus_per_task": 4,

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -3,6 +3,11 @@
   "task_list": [
     {
       "name": "scMultiplex Calculate Object Linking",
+      "category": "Registration",
+      "modality": "HCS",
+      "tags": [
+        "multiplexing"
+      ],
       "executable_non_parallel": "fractal/_image_based_registration_hcs_init.py",
       "executable_parallel": "fractal/calculate_object_linking.py",
       "meta_non_parallel": {
@@ -108,6 +113,11 @@
     },
     {
       "name": "scMultiplex Calculate Linking Consensus",
+      "category": "Registration",
+      "modality": "HCS",
+      "tags": [
+        "multiplexing"
+      ],
       "executable_non_parallel": "fractal/_init_group_by_well_for_multiplexing.py",
       "executable_parallel": "fractal/calculate_linking_consensus.py",
       "meta_non_parallel": {
@@ -198,6 +208,11 @@
     },
     {
       "name": "scMultiplex Relabel by Linking Consensus",
+      "category": "Registration",
+      "modality": "HCS",
+      "tags": [
+        "multiplexing"
+      ],
       "executable_non_parallel": "fractal/_image_based_registration_hcs_allrounds_init.py",
       "executable_parallel": "fractal/relabel_by_linking_consensus.py",
       "meta_non_parallel": {
@@ -297,6 +312,11 @@
     },
     {
       "name": "scMultiplex Calculate Platymatch Registration",
+      "category": "Registration",
+      "modality": "HCS",
+      "tags": [
+        "multiplexing"
+      ],
       "executable_non_parallel": "fractal/_image_based_registration_hcs_init.py",
       "executable_parallel": "fractal/calculate_platymatch_registration.py",
       "meta_non_parallel": {
@@ -455,6 +475,7 @@
     },
     {
       "name": "scMultiplex Surface Mesh Multiscale",
+      "modality": "HCS",
       "executable_non_parallel": "fractal/_init_group_by_well_for_multiplexing.py",
       "executable_parallel": "fractal/surface_mesh_multiscale.py",
       "meta_non_parallel": {
@@ -634,6 +655,8 @@
     },
     {
       "name": "scMultiplex Segment by Intensity Threshold",
+      "category": "Segmentation",
+      "modality": "HCS",
       "executable_non_parallel": "fractal/init_select_multiplexing_round.py",
       "executable_parallel": "fractal/segment_by_intensity_threshold.py",
       "meta_non_parallel": {
@@ -867,6 +890,8 @@
     },
     {
       "name": "scMultiplex Spherical Harmonics from Label Image",
+      "category": "Measurement",
+      "modality": "HCS",
       "executable_non_parallel": "fractal/_init_group_by_well_for_multiplexing.py",
       "executable_parallel": "fractal/spherical_harmonics_from_labelimage.py",
       "meta_non_parallel": {
@@ -981,6 +1006,8 @@
     },
     {
       "name": "scMultiplex Mesh Measurements",
+      "category": "Measurement",
+      "modality": "HCS",
       "executable_non_parallel": "fractal/_init_group_by_well_for_multiplexing.py",
       "executable_parallel": "fractal/scmultiplex_mesh_measurements.py",
       "meta_non_parallel": {
@@ -1119,6 +1146,12 @@
     },
     {
       "name": "scMultiplex Feature Measurements",
+      "category": "Measurement",
+      "tags": [
+        "regionprops",
+        "morphology",
+        "intensity"
+      ],
       "executable_parallel": "fractal/scmultiplex_feature_measurements.py",
       "meta_parallel": {
         "cpus_per_task": 4,
@@ -1275,5 +1308,6 @@
     }
   ],
   "has_args_schemas": true,
-  "args_schema_version": "pydantic_v2"
+  "args_schema_version": "pydantic_v2",
+  "authors": "Nicole Repina, Enrico Tagliavini, Tim-Oliver Buchholz, Joel L\u00fcthi"
 }

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -1309,5 +1309,5 @@
   ],
   "has_args_schemas": true,
   "args_schema_version": "pydantic_v2",
-  "authors": "Nicole Repina, Enrico Tagliavini, Tim-Oliver Buchholz, Joel L\u00fcthi"
+  "authors": "Nicole Repina, Enrico Tagliavini, Tim-Oliver Buchholz, Joel Luethi"
 }

--- a/src/scmultiplex/dev/create_manifest.py
+++ b/src/scmultiplex/dev/create_manifest.py
@@ -4,4 +4,5 @@ from fractal_tasks_core.dev.create_manifest import create_manifest
 
 if __name__ == "__main__":
     PACKAGE = "scmultiplex"
-    create_manifest(package=PACKAGE)
+    AUTHORS = "Nicole Repina, Enrico Tagliavini, Tim-Oliver Buchholz, Joel Lüthi"
+    create_manifest(package=PACKAGE, authors=AUTHORS)

--- a/src/scmultiplex/dev/create_manifest.py
+++ b/src/scmultiplex/dev/create_manifest.py
@@ -4,5 +4,5 @@ from fractal_tasks_core.dev.create_manifest import create_manifest
 
 if __name__ == "__main__":
     PACKAGE = "scmultiplex"
-    AUTHORS = "Nicole Repina, Enrico Tagliavini, Tim-Oliver Buchholz, Joel Lüthi"
+    AUTHORS = "Nicole Repina, Enrico Tagliavini, Tim-Oliver Buchholz, Joel Luethi"
     create_manifest(package=PACKAGE, authors=AUTHORS)

--- a/src/scmultiplex/dev/task_list.py
+++ b/src/scmultiplex/dev/task_list.py
@@ -23,6 +23,9 @@ TASK_LIST = [
         executable="fractal/calculate_object_linking.py",
         meta_init={"cpus_per_task": 1, "mem": 1000},
         meta={"cpus_per_task": 4, "mem": 16000},
+        category="Registration",
+        modality="HCS",
+        tags=["multiplexing"],
     ),
     CompoundTask(
         name="scMultiplex Calculate Linking Consensus",
@@ -30,6 +33,9 @@ TASK_LIST = [
         executable="fractal/calculate_linking_consensus.py",
         meta_init={"cpus_per_task": 1, "mem": 1000},
         meta={"cpus_per_task": 4, "mem": 16000},
+        category="Registration",
+        modality="HCS",
+        tags=["multiplexing"],
     ),
     CompoundTask(
         name="scMultiplex Relabel by Linking Consensus",
@@ -37,6 +43,9 @@ TASK_LIST = [
         executable="fractal/relabel_by_linking_consensus.py",
         meta_init={"cpus_per_task": 1, "mem": 1000},
         meta={"cpus_per_task": 4, "mem": 64000},
+        category="Registration",
+        modality="HCS",
+        tags=["multiplexing"],
     ),
     CompoundTask(
         name="scMultiplex Calculate Platymatch Registration",
@@ -44,6 +53,9 @@ TASK_LIST = [
         executable="fractal/calculate_platymatch_registration.py",
         meta_init={"cpus_per_task": 1, "mem": 1000},
         meta={"cpus_per_task": 4, "mem": 16000},
+        category="Registration",
+        modality="HCS",
+        tags=["multiplexing"],
     ),
     CompoundTask(
         name="scMultiplex Surface Mesh Multiscale",
@@ -51,6 +63,7 @@ TASK_LIST = [
         executable="fractal/surface_mesh_multiscale.py",
         meta_init={"cpus_per_task": 1, "mem": 1000},
         meta={"cpus_per_task": 4, "mem": 16000},
+        modality="HCS",
     ),
     CompoundTask(
         name="scMultiplex Segment by Intensity Threshold",
@@ -58,6 +71,8 @@ TASK_LIST = [
         executable="fractal/segment_by_intensity_threshold.py",
         meta_init={"cpus_per_task": 1, "mem": 1000},
         meta={"cpus_per_task": 4, "mem": 16000},
+        category="Segmentation",
+        modality="HCS",
     ),
     CompoundTask(
         name="scMultiplex Spherical Harmonics from Label Image",
@@ -65,6 +80,8 @@ TASK_LIST = [
         executable="fractal/spherical_harmonics_from_labelimage.py",
         meta_init={"cpus_per_task": 1, "mem": 1000},
         meta={"cpus_per_task": 4, "mem": 16000},
+        category="Measurement",
+        modality="HCS",
     ),
     CompoundTask(
         name="scMultiplex Mesh Measurements",
@@ -72,11 +89,15 @@ TASK_LIST = [
         executable="fractal/scmultiplex_mesh_measurements.py",
         meta_init={"cpus_per_task": 1, "mem": 1000},
         meta={"cpus_per_task": 4, "mem": 16000},
+        category="Measurement",
+        modality="HCS",
     ),
     ParallelTask(
         name="scMultiplex Feature Measurements",
         executable="fractal/scmultiplex_feature_measurements.py",
         meta={"cpus_per_task": 4, "mem": 16000},
+        category="Measurement",
+        tags=["regionprops", "morphology", "intensity"],
     ),
     ParallelTask(
         name="scMultiplex Expand Labels",

--- a/src/scmultiplex/dev/task_list.py
+++ b/src/scmultiplex/dev/task_list.py
@@ -73,6 +73,7 @@ TASK_LIST = [
         meta={"cpus_per_task": 4, "mem": 16000},
         category="Segmentation",
         modality="HCS",
+        tags=["Classical segmentation", "multiplexing"],
     ),
     CompoundTask(
         name="scMultiplex Spherical Harmonics from Label Image",

--- a/src/scmultiplex/dev/task_list.py
+++ b/src/scmultiplex/dev/task_list.py
@@ -25,7 +25,7 @@ TASK_LIST = [
         meta={"cpus_per_task": 4, "mem": 16000},
         category="Registration",
         modality="HCS",
-        tags=["multiplexing"],
+        tags=["multiplexing", "2D"],
     ),
     CompoundTask(
         name="scMultiplex Calculate Linking Consensus",
@@ -35,7 +35,7 @@ TASK_LIST = [
         meta={"cpus_per_task": 4, "mem": 16000},
         category="Registration",
         modality="HCS",
-        tags=["multiplexing"],
+        tags=["multiplexing", "2D", "3D"],
     ),
     CompoundTask(
         name="scMultiplex Relabel by Linking Consensus",
@@ -45,7 +45,7 @@ TASK_LIST = [
         meta={"cpus_per_task": 4, "mem": 64000},
         category="Registration",
         modality="HCS",
-        tags=["multiplexing"],
+        tags=["multiplexing", "2D", "3D"],
     ),
     CompoundTask(
         name="scMultiplex Calculate Platymatch Registration",
@@ -55,7 +55,7 @@ TASK_LIST = [
         meta={"cpus_per_task": 4, "mem": 16000},
         category="Registration",
         modality="HCS",
-        tags=["multiplexing"],
+        tags=["multiplexing", "3D"],
     ),
     CompoundTask(
         name="scMultiplex Surface Mesh Multiscale",
@@ -63,7 +63,9 @@ TASK_LIST = [
         executable="fractal/surface_mesh_multiscale.py",
         meta_init={"cpus_per_task": 1, "mem": 1000},
         meta={"cpus_per_task": 4, "mem": 16000},
+        category="Image Processing",
         modality="HCS",
+        tags=["3D", "mesh"],
     ),
     CompoundTask(
         name="scMultiplex Segment by Intensity Threshold",
@@ -73,7 +75,7 @@ TASK_LIST = [
         meta={"cpus_per_task": 4, "mem": 16000},
         category="Segmentation",
         modality="HCS",
-        tags=["Classical segmentation", "multiplexing"],
+        tags=["Classical segmentation", "3D"],
     ),
     CompoundTask(
         name="scMultiplex Spherical Harmonics from Label Image",
@@ -83,6 +85,7 @@ TASK_LIST = [
         meta={"cpus_per_task": 4, "mem": 16000},
         category="Measurement",
         modality="HCS",
+        tags=["3D"],
     ),
     CompoundTask(
         name="scMultiplex Mesh Measurements",
@@ -92,6 +95,7 @@ TASK_LIST = [
         meta={"cpus_per_task": 4, "mem": 16000},
         category="Measurement",
         modality="HCS",
+        tags=["3D", "mesh", "morphology"],
     ),
     ParallelTask(
         name="scMultiplex Feature Measurements",
@@ -104,5 +108,6 @@ TASK_LIST = [
         name="scMultiplex Expand Labels",
         executable="fractal/expand_labels.py",
         meta={"cpus_per_task": 4, "mem": 16000},
+        tags=["2D", "3D"],
     ),
 ]


### PR DESCRIPTION
Hey @nrepina,

As mentioned yesterday: We're adding metadata to the tasks to be able to build better task interfaces. I've created this PR to show how this metadata is structured. The core fields for each task are:

1. Category: Conversion, Segmentation, Registration, Measurement, Image Processing
2. Modality: HCS, lightsheet, EM
3. Tags: Arbitrary strings that are searchable and provide info about the task

Category & Modality work by convention, but you can add new entries when useful.

Additionally, there is now an "authors" field for the whole package.

In order for the future public Fractal page to list your tasks (see https://github.com/fractal-analytics-platform/fractal-analytics-platform.github.io/issues/6), the package needs to either be on PyPI or have github releases with whl files. As part of this PR, I'm adding some deployment steps to the Github CI that will create releases with whls when you add a tag. Let me know if that works for you.
Additionally, the CI includes an easy option to activate publishing to PyPI (which would be great for your package!). Feel free to turn it on by removing the `if false` option on the PyPI publishing in build_and_test.yml and following the setup steps here: https://github.com/fractal-analytics-platform/fractal-tasks-template/blob/main/DEVELOPERS_GUIDE.md
=> Pypi instructions: https://docs.pypi.org/trusted-publishers

---

What remains to be done:

1. Check whether my suggestions in the image list make sense
2. Add additional metadata, e.g. more tags
3. It would be great to mark the tasks as HCS specific which assume that there is a plate. I did it for some where it appears obvious. Any task that works for HCS, but also works for an arbitrary list of zarr_urls doesn't need that modality tag (e.g. the feature measurement task).
4. Decide whether the whl releases is something you want
5. Decide whether you want to publish the package on PyPI