### PR TITLE
Update Expansion and add Label Fusion tasks

### DIFF
--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -1691,6 +1691,80 @@
         "title": "ApplyZIlluminationCorrection"
       },
       "docs_link": "https://github.com/fmi-basel/gliberal-scMultipleX"
+    },
+    {
+      "name": "scMultiplex Fuse Touching Labels",
+      "category": "Image Processing",
+      "tags": [
+        "2D"
+      ],
+      "docs_info": "### Purpose\n- Fuse touching labels in segmentation images, in 2D or 3D. Connected components are identified during labeling\n    based on the connectivity argument. For a more detailed explanation of 1- or 2- connectivity, see documentation\n    of skimage.measure.label() function. When set to None (default), full connectivity (ndim of input array) is used.\n\n- Input is segmentation image with 0 value for background. Anything above 0 is assumed to be a labeled object.\n    Touching labels are labeled in numerically increasing order starting from 1 to n, where n is the number of\n    connected components (objects) identified.\n\n- This task has been tested for fusion of 2D MIP segmentation. Since fusion must occur on the full well numpy\n    array loaded into memory, performance may be poor for large 3D arrays.\n\n### Outputs\n- The fused label image is saved as a new label in zarr, with name {label_name_to_fuse}_fused.\n- The new ROI table for the fused label image is saved as a masking ROI table, with name\n    {label_name_to_fuse}_fused_ROI_table.\n",
+      "executable_non_parallel": "fractal/init_select_many_rounds.py",
+      "executable_parallel": "fractal/fuse_touching_labels.py",
+      "meta_parallel": {
+        "cpus_per_task": 4,
+        "mem": 16000
+      },
+      "args_schema_non_parallel": {
+        "additionalProperties": false,
+        "properties": {
+          "zarr_urls": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Zarr Urls",
+            "type": "array",
+            "description": "List of paths or urls to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
+          },
+          "zarr_dir": {
+            "title": "Zarr Dir",
+            "type": "string",
+            "description": "path of the directory where the new OME-Zarrs will be created. Not used by this task. (standard argument for Fractal tasks, managed by Fractal server)."
+          },
+          "select_acquisitions": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Select Acquisitions",
+            "type": "array",
+            "description": "List of rounds to which correction should be applied, list of integers."
+          }
+        },
+        "required": [
+          "zarr_urls",
+          "zarr_dir",
+          "select_acquisitions"
+        ],
+        "type": "object",
+        "title": "InitSelectManyRounds"
+      },
+      "args_schema_parallel": {
+        "additionalProperties": false,
+        "properties": {
+          "zarr_url": {
+            "title": "Zarr Url",
+            "type": "string",
+            "description": "Missing description"
+          },
+          "label_name_to_fuse": {
+            "default": "org",
+            "title": "Label Name To Fuse",
+            "type": "string",
+            "description": "Missing description"
+          },
+          "connectivity": {
+            "title": "Connectivity",
+            "type": "integer",
+            "description": "Missing description"
+          }
+        },
+        "required": [
+          "zarr_url"
+        ],
+        "type": "object",
+        "title": "FuseTouchingLabels"
+      },
+      "docs_link": "https://github.com/fmi-basel/gliberal-scMultipleX"
     }
   ],
   "has_args_schemas": true,

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -1290,15 +1290,50 @@
     },
     {
       "name": "scMultiplex Expand Labels",
+      "category": "Image Processing",
       "tags": [
         "2D",
         "3D"
       ],
       "docs_info": "### Purpose\n- Expands segmented **labels** in 2D or 3D images **without overlap**.\n- Supports expansion by a fixed pixel distance or dynamically based on **label size**.\n- Optionally masks expanded labels using **parent objects** to prevent spillover.\n- Outputs an expanded label image and preserves non-overlapping object boundaries.\n\n### Outputs\n- A new **expanded label image** saved with an `_expanded` suffix.\n\n### Limitations\n- If masking by parent is enabled, the parent object label image must be provided.\n- Expansion beyond object boundaries may be clipped, depending on the surrounding labels and image dimensions.\n",
+      "executable_non_parallel": "fractal/init_select_many_rounds.py",
       "executable_parallel": "fractal/expand_labels.py",
       "meta_parallel": {
         "cpus_per_task": 4,
         "mem": 16000
+      },
+      "args_schema_non_parallel": {
+        "additionalProperties": false,
+        "properties": {
+          "zarr_urls": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Zarr Urls",
+            "type": "array",
+            "description": "List of paths or urls to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
+          },
+          "zarr_dir": {
+            "title": "Zarr Dir",
+            "type": "string",
+            "description": "path of the directory where the new OME-Zarrs will be created. Not used by this task. (standard argument for Fractal tasks, managed by Fractal server)."
+          },
+          "select_acquisitions": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Select Acquisitions",
+            "type": "array",
+            "description": "List of rounds to which correction should be applied, list of integers."
+          }
+        },
+        "required": [
+          "zarr_urls",
+          "zarr_dir",
+          "select_acquisitions"
+        ],
+        "type": "object",
+        "title": "InitSelectManyRounds"
       },
       "args_schema_parallel": {
         "additionalProperties": false,
@@ -1306,7 +1341,7 @@
           "zarr_url": {
             "title": "Zarr Url",
             "type": "string",
-            "description": "Path or url to the individual OME-Zarr image to be processed. Refers to the zarr_url of the reference acquisition. (standard argument for Fractal tasks, managed by Fractal server)."
+            "description": "Path or url to the individual OME-Zarr image to be processed."
           },
           "label_name_to_expand": {
             "default": "nuc",
@@ -1314,21 +1349,27 @@
             "type": "string",
             "description": "Label name of segmentation to be expanded."
           },
-          "group_by": {
-            "title": "Group By",
-            "type": "string",
-            "description": "Label name of segmentated objects that are parents of label_name. If None (default), no grouping is applied and expansion is calculated for the input object (label_name_to_expand). Instead, if a group_by label is specified, the label_name_to_expand objects will be masked and grouped by this object. For example, when group_by = 'org', the nuclear segmentation is masked by the organoid parent and all nuclei belonging to the parent are loaded as a label image."
-          },
           "roi_table": {
             "default": "org_ROI_table_linked",
             "title": "Roi Table",
             "type": "string",
-            "description": "Name of the ROI table used to iterate over objects and load object regions. If group_by is passed, this is the ROI table for the group_by objects, e.g. org_ROI_table."
+            "description": "Name of the ROI table used to iterate over objects and load object regions. If a table of type \"roi_table\" is passed, e.g. well_ROI_table, all objects for each region in the table will be loaded and expanded simultaneously. If a table of type \"masking_roi_table\" is passed, e.g. a segmentation ROI table, the task iterates over these objects and loads only the children (i.e. label_name_to_expand) that belong to the parent object."
+          },
+          "masking_label_map": {
+            "title": "Masking Label Map",
+            "type": "string",
+            "description": "Label name of segmented objects that are parents of label_name. This input is mandatory if a roi table of type \"masking_roi_table\" is provided. It is the name of the label map that corresponds to the input ROI table. The masking_label_map will be used to mask label_name_to_expand objects, to only select children belonging to given parent."
+          },
+          "mask_output": {
+            "default": true,
+            "title": "Mask Output",
+            "type": "boolean",
+            "description": "If True, expanded label is masked by parent label. Only used if masking_label_map is provided. Recommended to set as True, to avoid overwriting of children labels between neighboring parents. However, it may lead to expanded results to be cropped by parent mask; in this case, the parent mask can first be expanded."
           },
           "expand_by_pixels": {
             "title": "Expand By Pixels",
             "type": "integer",
-            "description": "Integer value for pixel distance to expand by."
+            "description": "Default expansion parameter. Integer value for pixel distance to expand by."
           },
           "calculate_image_based_expansion_distance": {
             "default": false,
@@ -1339,13 +1380,7 @@
           "expand_by_factor": {
             "title": "Expand By Factor",
             "type": "number",
-            "description": "Multiplier that specifies pixels by which to expand each label. Float in range [0, 1 or higher], e.g. 0.2 means that 20% of mean equivalent diameter of labels in region is used."
-          },
-          "mask_expansion_by_parent": {
-            "default": false,
-            "title": "Mask Expansion By Parent",
-            "type": "boolean",
-            "description": "If True, final expanded labels are masked by group_by object. Recommended to set to True for child/parent masking."
+            "description": "Only used if calculate_image_based_expansion_distance is True. Multiplier that specifies pixels by which to expand each label. Float in range [0, 1 or higher], e.g. 0.2 means that 20% of mean equivalent diameter of labels in region is used."
           }
         },
         "required": [

--- a/src/scmultiplex/dev/task_info/fuse_touching_labels.md
+++ b/src/scmultiplex/dev/task_info/fuse_touching_labels.md
@@ -1,0 +1,16 @@
+### Purpose
+- Fuse touching labels in segmentation images, in 2D or 3D. Connected components are identified during labeling
+    based on the connectivity argument. For a more detailed explanation of 1- or 2- connectivity, see documentation
+    of skimage.measure.label() function. When set to None (default), full connectivity (ndim of input array) is used.
+
+- Input is segmentation image with 0 value for background. Anything above 0 is assumed to be a labeled object.
+    Touching labels are labeled in numerically increasing order starting from 1 to n, where n is the number of
+    connected components (objects) identified.
+
+- This task has been tested for fusion of 2D MIP segmentation. Since fusion must occur on the full well numpy
+    array loaded into memory, performance may be poor for large 3D arrays.
+
+### Outputs
+- The fused label image is saved as a new label in zarr, with name {label_name_to_fuse}_fused.
+- The new ROI table for the fused label image is saved as a masking ROI table, with name
+    {label_name_to_fuse}_fused_ROI_table.

--- a/src/scmultiplex/dev/task_list.py
+++ b/src/scmultiplex/dev/task_list.py
@@ -147,4 +147,13 @@ TASK_LIST = [
         input_types=dict(z_illum_corrected=False, is_3D=True),
         output_types=dict(z_illum_corrected=True, is_3D=True),
     ),
+    CompoundTask(
+        name="scMultiplex Fuse Touching Labels",
+        executable_init="fractal/init_select_many_rounds.py",
+        executable="fractal/fuse_touching_labels.py",
+        meta={"cpus_per_task": 4, "mem": 16000},
+        category="Image Processing",
+        tags=["2D"],
+        docs_info="file:task_info/fuse_touching_labels.md",
+    ),
 ]

--- a/src/scmultiplex/dev/task_list.py
+++ b/src/scmultiplex/dev/task_list.py
@@ -113,10 +113,12 @@ TASK_LIST = [
         tags=["regionprops", "morphology", "intensity"],
         docs_info="file:task_info/feature_measurements.md",
     ),
-    ParallelTask(
+    CompoundTask(
         name="scMultiplex Expand Labels",
+        executable_init="fractal/init_select_many_rounds.py",
         executable="fractal/expand_labels.py",
         meta={"cpus_per_task": 4, "mem": 16000},
+        category="Image Processing",
         tags=["2D", "3D"],
         docs_info="file:task_info/expand_labels.md",
     ),

--- a/src/scmultiplex/fractal/expand_labels.py
+++ b/src/scmultiplex/fractal/expand_labels.py
@@ -56,7 +56,9 @@ def expand_labels(
     within image (e.g. by specifying a segmentation masking ROI table) as input roi_table. In the later case, a common
     use case would be to expand in 3D nuclei of each organoid in dataset.
 
-    Output: the expanded label image is saved as a new label in zarr, with name {label_name_to_expand}_expanded.
+    Output: the expanded label image is saved as a new label in zarr, with name {label_name_to_expand}_expanded. The
+    new ROI table for the expanded label image is saved as a masking ROI table, with name
+    {label_name_to_expand}_expanded_ROI_table.
 
     Args:
         zarr_url: Path or url to the individual OME-Zarr image to be processed.
@@ -264,8 +266,8 @@ def expand_labels(
         ##############
 
         # Store labels as new label map in zarr
-        # Note that pixels of overlap in the case where two labelmaps are touching are overwritten by the last
-        # written object
+        # IF mask_output=False and expanded labels extend beyond parent label, note that pixels of overlap between
+        # children of neighboring parents will be overwritten by the last written object.
 
         save_new_label_with_overlap(
             seg_expanded,

--- a/src/scmultiplex/fractal/fuse_touching_labels.py
+++ b/src/scmultiplex/fractal/fuse_touching_labels.py
@@ -1,0 +1,151 @@
+# Copyright (C) 2025 Friedrich Miescher Institute for Biomedical Research
+
+##############################################################################
+#                                                                            #
+# Author: Nicole Repina              <nicole.repina@fmi.ch>                  #
+#                                                                            #
+##############################################################################
+import logging
+from typing import Any, Union
+
+import numpy as np
+import pandas as pd
+from fractal_tasks_core.pyramids import build_pyramid
+from fractal_tasks_core.roi import array_to_bounding_box_table
+from pydantic import validate_call
+
+from scmultiplex.fractal.fractal_helper_functions import (
+    initialize_new_label,
+    load_image_array,
+    save_masking_roi_table_from_df_list,
+)
+from scmultiplex.meshing.LabelFusionFunctions import simple_fuse_labels
+
+logger = logging.getLogger(__name__)
+
+
+@validate_call
+def fuse_touching_labels(
+    *,
+    # Fractal arguments
+    zarr_url: str,
+    # Task-specific arguments
+    label_name_to_fuse: str = "org",
+    connectivity: Union[int, None] = None,
+) -> dict[str, Any]:
+    """
+    Fuse touching labels in segmentation images, in 2D or 3D. Connected components are identified during labeling
+    based on the connectivity argument. For a more detailed explanation of 1- or 2- connectivity, see documentation
+    of skimage.measure.label() function. When set to None (default), full connectivity (ndim of input array) is used.
+
+    Input is segmentation image with 0 value for background. Anything above 0 is assumed to be a labeled object.
+    Touching labels are labeled in numerically increasing order starting from 1 to n, where n is the number of
+    connected components (objects) identified.
+
+    This task has been tested for fusion of 2D MIP segmentation. Since fusion must occur on the full well numpy
+    array loaded into memory, performance may be poor for large 3D arrays.
+
+    Output: the fused label image is saved as a new label in zarr, with name {label_name_to_fuse}_fused. The
+    new ROI table for the fused label image is saved as a masking ROI table, with name
+    {label_name_to_fuse}_fused_ROI_table.
+
+    Args:
+        zarr_url: Path or url to the individual OME-Zarr image to be processed.
+        label_name_to_fuse: Label name of segmentation to be fused.
+        connectivity: Maximum number of orthogonal hops to consider a pixel/voxel as a neighbor. Accepted values
+        are ranging from 1 to input.ndim. If None, a full connectivity of input.ndim is used.
+    """
+
+    logger.info(f"Running for {zarr_url=}. \n" f"and label image {label_name_to_fuse}.")
+
+    # always use highest resolution label
+    level = 0
+    label_url = f"{zarr_url}/labels/{label_name_to_fuse}"
+
+    label_dask, ngffmeta, xycoars, pixmeta = load_image_array(label_url, level)
+
+    output_label_name = f"{label_name_to_fuse}_fused"
+    output_roi_table_name = f"{label_name_to_fuse}_fused_ROI_table"
+
+    shape = label_dask.shape
+    chunks = label_dask.chunksize
+
+    initialize_new_label(
+        zarr_url,
+        shape,
+        chunks,
+        np.uint32,
+        label_name_to_fuse,
+        output_label_name,
+        logger,
+    )
+
+    logger.info("Started computation to fuse labels.")
+
+    fused_numpy, fused_dask, label_count, connectivity_comp = simple_fuse_labels(
+        label_dask, connectivity
+    )
+
+    fused_dask.to_zarr(
+        f"{zarr_url}/labels/{output_label_name}/0",
+        overwrite=True,
+        dimension_separator="/",
+        return_stored=False,
+        compute=True,
+    )
+
+    logger.info(
+        f"Finished computation to fuse labels, found {label_count} connected components using "
+        f"connectivity {connectivity_comp}."
+    )
+
+    ##############
+    # Build pyramid and save new masking ROI table of expanded labels ###
+    ##############
+    # Starting from on-disk highest-resolution data, build and write to disk a pyramid of coarser levels
+    build_pyramid(
+        zarrurl=f"{zarr_url}/labels/{output_label_name}",
+        overwrite=True,
+        num_levels=ngffmeta.num_levels,
+        coarsening_xy=ngffmeta.coarsening_xy,
+        chunksize=chunks,
+        aggregation_function=np.max,
+    )
+
+    logger.info(
+        f"Built a pyramid for the {zarr_url}/labels/{output_label_name} label image."
+    )
+
+    bbox_df = array_to_bounding_box_table(
+        fused_numpy,
+        pixmeta,
+    )
+
+    bbox_table = save_masking_roi_table_from_df_list(
+        [bbox_df],
+        zarr_url,
+        output_roi_table_name,
+        output_label_name,
+        overwrite=True,
+    )
+
+    logger.debug(
+        pd.DataFrame(
+            bbox_table.X,
+            index=bbox_table.obs_vector("label"),
+            columns=bbox_table.var_names,
+        )
+    )
+
+    logger.info(f"End fuse_touching_labels task for {zarr_url}")
+
+    return {}
+
+
+if __name__ == "__main__":
+    from fractal_tasks_core.tasks._utils import run_fractal_task
+
+    run_fractal_task(
+        task_function=fuse_touching_labels,
+        logger_name=logger.name,
+    )

--- a/src/scmultiplex/fractal/init_select_many_rounds.py
+++ b/src/scmultiplex/fractal/init_select_many_rounds.py
@@ -1,0 +1,74 @@
+# Copyright 2024 (C) Friedrich Miescher Institute for Biomedical Research and
+# University of Zurich
+#
+# Original authors:
+# Tommaso Comparin <tommaso.comparin@exact-lab.it>
+# Joel Lüthi <joel.luethi@uzh.ch>
+# Nicole Repina <nicole.repina@fmi.ch>
+#
+# This file is part of Fractal and was originally developed by eXact lab S.r.l.
+# <exact-lab.it> under contract with Liberali Lab from the Friedrich Miescher
+# Institute for Biomedical Research and Pelkmans Lab from the University of
+# Zurich.
+"""
+Select multiple multiplexing rounds for processing. Can also select single round, e.g. [0]
+"""
+import logging
+from typing import Any
+
+from fractal_tasks_core.utils import create_well_acquisition_dict
+from pydantic import validate_call
+
+logger = logging.getLogger(__name__)
+
+
+@validate_call
+def init_select_many_rounds(
+    *,
+    # Fractal parameters
+    zarr_urls: list[str],
+    zarr_dir: str,
+    # Core parameters
+    select_acquisitions: list[int],
+) -> dict[str, list[dict[str, Any]]]:
+    """
+    Finds images for desired acquisition per well.
+
+    Returns the parallelization_list.
+
+    Args:
+        zarr_urls: List of paths or urls to the individual OME-Zarr image to
+            be processed.
+            (standard argument for Fractal tasks, managed by Fractal server).
+        zarr_dir: path of the directory where the new OME-Zarrs will be
+            created. Not used by this task.
+            (standard argument for Fractal tasks, managed by Fractal server).
+        select_acquisitions: List of rounds to which correction should be applied, list of integers.
+    """
+    logger.info(f"Running `init_select_illumination_round` for {zarr_urls=}")
+    image_groups = create_well_acquisition_dict(zarr_urls)
+
+    # Create the parallelization list
+    parallelization_list = []
+    for key, image_group in image_groups.items():
+
+        # Create a parallelization list entry for selected image
+        for acquisition, zarr_url in image_group.items():
+            if acquisition in select_acquisitions:
+                parallelization_list.append(
+                    dict(
+                        zarr_url=zarr_url,
+                        init_args=dict(),
+                    )
+                )
+
+    return dict(parallelization_list=parallelization_list)
+
+
+if __name__ == "__main__":
+    from fractal_tasks_core.tasks._utils import run_fractal_task
+
+    run_fractal_task(
+        task_function=init_select_many_rounds,
+        logger_name=logger.name,
+    )


### PR DESCRIPTION
- Expand Labels task can now take 2D MIP zarr as input
- ROI table corresponding to expanded label map saved to zarr group as a new masking table
- New label fusion task to fuse touching labels to single ID