### PR TITLE
Bug fixes

### DIFF
--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -3491,6 +3491,110 @@
         "title": "ScmultiplexPixelMeasurements"
       },
       "docs_link": "https://github.com/fmi-basel/gliberal-scMultipleX"
+    },
+    {
+      "name": "scMultiplex Copy Data from Reference to Moving Rounds",
+      "category": "Registration",
+      "modality": "HCS",
+      "tags": [
+        "multiplexing",
+        "3D",
+        "2D"
+      ],
+      "docs_info": "## Purpose\n\n- Copy ROI tables from the reference multiplexing round to all submitted moving rounds.\n- Automatically copy the corresponding label images for any masking ROI tables.\n- Preserve the original label image data type when creating copied labels.\n- Skip the reference round; only moving rounds are modified.\n- Existing labels and tables are overwritten only if `overwrite=True`.\n\n\n## Inputs\n\n- **roi_table_names_to_copy_from_ref**: List of ROI table names to copy from the reference round. For tables of type `masking_roi_table`, the corresponding label images are copied automatically.\n- **overwrite** *(default: `False`)*: If `True`, overwrite existing tables and labels in the moving rounds.\n\n## Outputs\n\n- Copies the requested ROI tables from the reference round to each moving round.\n- Copies any label images referenced by masking ROI tables to the corresponding moving rounds.\n- Builds label pyramids for copied label images.\n\n## Limitations\n\n- Assumes that reference and moving images have compatible spatial metadata (shape, pixel size, axes).\n- Only copies labels and tables; in future consider supporting copying of specific subfolders, e.g. meshes or registration, if needed.\n",
+      "type": "compound",
+      "executable_non_parallel": "fractal/init_select_all_knowing_reference.py",
+      "executable_parallel": "fractal/copy_data_from_ref_to_moving_rounds.py",
+      "meta_non_parallel": {
+        "cpus_per_task": 1,
+        "mem": 1000
+      },
+      "meta_parallel": {
+        "cpus_per_task": 4,
+        "mem": 16000
+      },
+      "args_schema_non_parallel": {
+        "additionalProperties": false,
+        "properties": {
+          "zarr_urls": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Zarr Urls",
+            "type": "array",
+            "description": "List of paths or urls to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
+          },
+          "zarr_dir": {
+            "title": "Zarr Dir",
+            "type": "string",
+            "description": "path of the directory where the new OME-Zarrs will be created. Not used by this task. (standard argument for Fractal tasks, managed by Fractal server)."
+          },
+          "reference_acquisition": {
+            "default": 0,
+            "title": "Reference Acquisition",
+            "type": "integer",
+            "description": "Which acquisition to register against. Needs to match the acquisition metadata in the OME-Zarr image."
+          }
+        },
+        "required": [
+          "zarr_urls",
+          "zarr_dir"
+        ],
+        "type": "object",
+        "title": "InitSelectAllKnowingReference"
+      },
+      "args_schema_parallel": {
+        "$defs": {
+          "InitArgsRegistration": {
+            "description": "Registration init args.",
+            "properties": {
+              "reference_zarr_url": {
+                "title": "Reference Zarr Url",
+                "type": "string"
+              }
+            },
+            "required": [
+              "reference_zarr_url"
+            ],
+            "title": "InitArgsRegistration",
+            "type": "object"
+          }
+        },
+        "additionalProperties": false,
+        "properties": {
+          "zarr_url": {
+            "title": "Zarr Url",
+            "type": "string",
+            "description": "Path or url to the individual OME-Zarr image to be processed. (standard argument for Fractal tasks, managed by Fractal server)."
+          },
+          "init_args": {
+            "$ref": "#/$defs/InitArgsRegistration",
+            "title": "Init Args",
+            "description": "Intialization arguments provided by `init_select_all_knowing_reference`. They contain the reference_zarr_url information. (standard argument for Fractal tasks, managed by Fractal server)."
+          },
+          "roi_table_names_to_copy_from_ref": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Roi Table Names To Copy From Ref",
+            "type": "array",
+            "description": "List of ROI table names present in reference round to copy over. The corresponding label of masking ROI tables are also copied over."
+          },
+          "overwrite": {
+            "default": false,
+            "title": "Overwrite",
+            "type": "boolean",
+            "description": "If True, overwrite labels and tables with same name in registered zarr image."
+          }
+        },
+        "required": [
+          "zarr_url",
+          "init_args"
+        ],
+        "type": "object",
+        "title": "CopyDataFromRefToMovingRounds"
+      },
+      "docs_link": "https://github.com/fmi-basel/gliberal-scMultipleX"
     }
   ],
   "has_args_schemas": true,

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -2346,6 +2346,12 @@
             "title": "Remove Nonsurface Labels",
             "type": "boolean",
             "description": "If true, remove child labels that are not on organoid surface, as determined by Annotate_mesh_by_child_features\" task. The values to be removed are loaded from disk."
+          },
+          "force_output_dtype_uint32": {
+            "default": false,
+            "title": "Force Output Dtype Uint32",
+            "type": "boolean",
+            "description": "If True, force the dtype of the output cleaned label to be uin32. If False, the dtype of input child label image is used."
           }
         },
         "required": [

--- a/src/scmultiplex/__FRACTAL_MANIFEST__.json
+++ b/src/scmultiplex/__FRACTAL_MANIFEST__.json
@@ -2347,11 +2347,11 @@
             "type": "boolean",
             "description": "If true, remove child labels that are not on organoid surface, as determined by Annotate_mesh_by_child_features\" task. The values to be removed are loaded from disk."
           },
-          "force_output_dtype_uint32": {
+          "force_output_type_to_uint32": {
             "default": false,
-            "title": "Force Output Dtype Uint32",
+            "title": "Force Output Type To Uint32",
             "type": "boolean",
-            "description": "If True, force the dtype of the output cleaned label to be uin32. If False, the dtype of input child label image is used."
+            "description": "If True, force the dtype of the output cleaned label to be uint32. If False, the dtype of input child label image is used."
           }
         },
         "required": [

--- a/src/scmultiplex/dev/task_info/copy_data_from_ref_to_moving_rounds.md
+++ b/src/scmultiplex/dev/task_info/copy_data_from_ref_to_moving_rounds.md
@@ -1,0 +1,24 @@
+## Purpose
+
+- Copy ROI tables from the reference multiplexing round to all submitted moving rounds.
+- Automatically copy the corresponding label images for any masking ROI tables.
+- Preserve the original label image data type when creating copied labels.
+- Skip the reference round; only moving rounds are modified.
+- Existing labels and tables are overwritten only if `overwrite=True`.
+
+
+## Inputs
+
+- **roi_table_names_to_copy_from_ref**: List of ROI table names to copy from the reference round. For tables of type `masking_roi_table`, the corresponding label images are copied automatically.
+- **overwrite** *(default: `False`)*: If `True`, overwrite existing tables and labels in the moving rounds.
+
+## Outputs
+
+- Copies the requested ROI tables from the reference round to each moving round.
+- Copies any label images referenced by masking ROI tables to the corresponding moving rounds.
+- Builds label pyramids for copied label images.
+
+## Limitations
+
+- Assumes that reference and moving images have compatible spatial metadata (shape, pixel size, axes).
+- Only copies labels and tables; in future consider supporting copying of specific subfolders, e.g. meshes or registration, if needed.

--- a/src/scmultiplex/dev/task_list.py
+++ b/src/scmultiplex/dev/task_list.py
@@ -307,4 +307,15 @@ TASK_LIST = [
         tags=["2D", "3D", "intensity"],
         docs_info="file:task_info/scmultiplex_pixel_measurements.md",
     ),
+    CompoundTask(
+        name="scMultiplex Copy Data from Reference to Moving Rounds",
+        executable_init="fractal/init_select_all_knowing_reference.py",
+        executable="fractal/copy_data_from_ref_to_moving_rounds.py",
+        meta_init={"cpus_per_task": 1, "mem": 1000},
+        meta={"cpus_per_task": 4, "mem": 16000},
+        category="Registration",
+        modality="HCS",
+        tags=["multiplexing", "3D", "2D"],
+        docs_info="file:task_info/copy_data_from_ref_to_moving_rounds.md",
+    ),
 ]

--- a/src/scmultiplex/fractal/cleanup_3d_child_labels.py
+++ b/src/scmultiplex/fractal/cleanup_3d_child_labels.py
@@ -46,7 +46,7 @@ def cleanup_3d_child_labels(
     child_volume_filter_threshold: float = 0.05,
     repair_uint16_clipped_labels: bool = False,
     remove_nonsurface_labels: bool = False,
-    force_output_dtype_uint32: bool = False,
+    force_output_type_to_uint32: bool = False,
 ) -> None:
     """
 
@@ -72,7 +72,7 @@ def cleanup_3d_child_labels(
             values get remapped to monotonically increasing values 65536, 65537, etc.
         remove_nonsurface_labels: If true, remove child labels that are not on organoid surface, as
             determined by Annotate_mesh_by_child_features" task. The values to be removed are loaded from disk.
-        force_output_dtype_uint32: If True, force the dtype of the output cleaned label to be uin32. If False, the
+        force_output_type_to_uint32: If True, force the dtype of the output cleaned label to be uint32. If False, the
             dtype of input child label image is used.
 
     """
@@ -116,7 +116,7 @@ def cleanup_3d_child_labels(
     start_label = 65536
 
     # Initialize zarr with NGIO
-    if force_output_dtype_uint32:
+    if force_output_type_to_uint32:
         output_dtype = np.uint32
     else:
         output_dtype = input_child_label_dtype

--- a/src/scmultiplex/fractal/cleanup_3d_child_labels.py
+++ b/src/scmultiplex/fractal/cleanup_3d_child_labels.py
@@ -46,6 +46,7 @@ def cleanup_3d_child_labels(
     child_volume_filter_threshold: float = 0.05,
     repair_uint16_clipped_labels: bool = False,
     remove_nonsurface_labels: bool = False,
+    force_output_dtype_uint32: bool = False,
 ) -> None:
     """
 
@@ -71,6 +72,8 @@ def cleanup_3d_child_labels(
             values get remapped to monotonically increasing values 65536, 65537, etc.
         remove_nonsurface_labels: If true, remove child labels that are not on organoid surface, as
             determined by Annotate_mesh_by_child_features" task. The values to be removed are loaded from disk.
+        force_output_dtype_uint32: If True, force the dtype of the output cleaned label to be uin32. If False, the
+            dtype of input child label image is used.
 
     """
     ome_zarr = open_ome_zarr_container(zarr_url)
@@ -85,6 +88,11 @@ def cleanup_3d_child_labels(
     masked_image = ome_zarr.get_masked_label(
         label_name=child_label_name, masking_label_name=parent_label_name
     )
+
+    # Get input label dtype
+    source_label = ome_zarr.get_label(child_label_name)
+    source_array = source_label.get_array(mode="dask")
+    input_child_label_dtype = source_array.dtype
 
     # Pixel sizes as list: [z,y,x]
     pixel_size = masked_image.pixel_size
@@ -108,7 +116,12 @@ def cleanup_3d_child_labels(
     start_label = 65536
 
     # Initialize zarr with NGIO
-    ome_zarr.derive_label(name=output_label_name, overwrite=True)
+    if force_output_dtype_uint32:
+        output_dtype = np.uint32
+    else:
+        output_dtype = input_child_label_dtype
+
+    ome_zarr.derive_label(name=output_label_name, dtype=output_dtype, overwrite=True)
 
     if remove_nonsurface_labels:
         # Load label info to remove

--- a/src/scmultiplex/fractal/copy_data_from_ref_to_moving_rounds.py
+++ b/src/scmultiplex/fractal/copy_data_from_ref_to_moving_rounds.py
@@ -1,0 +1,106 @@
+# Copyright 2026 (C) Friedrich Miescher Institute for Biomedical Research and
+# University of Zurich
+#
+# Original authors:
+# Nicole Repina <nicole.repina@fmi.ch>
+#
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+from fractal_tasks_core.tasks.io_models import InitArgsRegistration
+from ngio import open_ome_zarr_container
+from ngio.utils import ngio_logger
+from pydantic import validate_call
+
+from scmultiplex.utils.ngio_utils import get_acquisition_id
+
+# Configure logging
+ngio_logger.setLevel("ERROR")
+logger = logging.getLogger("copy_data_from_ref_to_moving_rounds")
+
+
+@validate_call
+def copy_data_from_ref_to_moving_rounds(
+    *,
+    # Fractal arguments
+    zarr_url: str,
+    init_args: InitArgsRegistration,
+    # Task-specific arguments
+    roi_table_names_to_copy_from_ref: Optional[list[str]] = None,
+    overwrite: bool = False,
+):
+    """
+    Copy data (e.g. tables, corresponding label images) from reference to moving multiplexing rounds.
+
+    Args:
+        zarr_url: Path or url to the individual OME-Zarr image to be processed.
+            (standard argument for Fractal tasks, managed by Fractal server).
+        init_args: Intialization arguments provided by
+            `init_select_all_knowing_reference`. They contain the reference_zarr_url information.
+            (standard argument for Fractal tasks, managed by Fractal server).
+        roi_table_names_to_copy_from_ref: List of ROI table names present in reference round to copy
+            over. The corresponding label of masking ROI tables are also copied over.
+        overwrite: If True, overwrite labels and tables with same name in registered zarr image.
+
+    """
+    # iterate over each round, not pairwise loading
+    reference_zarr_url = init_args.reference_zarr_url
+
+    # Get id of current moving acquisition from plate/well metadata as int, e.g. 1
+    reference_acquisition_id = get_acquisition_id(reference_zarr_url)
+    current_acquisition_id = get_acquisition_id(zarr_url)
+
+    # skip the reference round
+    if current_acquisition_id == reference_acquisition_id:
+        return
+
+    # Open the ome-zarr image container from which to copy
+    source_ome_zarr = open_ome_zarr_container(reference_zarr_url)
+    target_zarr_image_name = os.path.basename(zarr_url)
+    target_ome_zarr = open_ome_zarr_container(zarr_url)
+
+    if roi_table_names_to_copy_from_ref is not None:
+        label_names_to_copy = []
+
+        # Copy tables
+        for table_name in roi_table_names_to_copy_from_ref:
+            table = source_ome_zarr.get_table(table_name)
+
+            logger.info(
+                f"Copying table {table_name} from registered reference round to "
+                f"{target_zarr_image_name}."
+            )
+
+            target_ome_zarr.add_table(table_name, table, overwrite=overwrite)
+            # Make list of labels to copy
+            if table.type() == "masking_roi_table":
+                # get name of corresponding label as stored in table metadata
+                label_names_to_copy.append(Path(table._meta.region.path).name)
+
+        # Copy labels
+        for i, label_name in enumerate(label_names_to_copy):
+            logger.info(
+                f"Copying label {label_name} from registered reference round to "
+                f"{target_zarr_image_name} as {label_name}."
+            )
+
+            label_image = source_ome_zarr.get_label(name=label_name)
+            label_image_dask = label_image.get_array(mode="dask")
+            new_label = target_ome_zarr.derive_label(
+                label_name,
+                dtype=label_image_dask.dtype,
+                overwrite=overwrite,
+            )
+            new_label.set_array(label_image_dask)
+            new_label.consolidate()
+
+    return
+
+
+if __name__ == "__main__":
+    from fractal_task_tools.task_wrapper import run_fractal_task
+
+    run_fractal_task(task_function=copy_data_from_ref_to_moving_rounds)

--- a/src/scmultiplex/fractal/expand_labels.py
+++ b/src/scmultiplex/fractal/expand_labels.py
@@ -156,7 +156,7 @@ def expand_labels(
     output_roi_table_name = f"{output_label_name}_ROI_table"
 
     # Initialize zarr with NGIO
-    ome_zarr.derive_label(name=output_label_name, overwrite=True)
+    ome_zarr.derive_label(name=output_label_name, ref_image=label_image, overwrite=True)
 
     ##############
     # Apply expansion ###

--- a/src/scmultiplex/fractal/fuse_touching_labels.py
+++ b/src/scmultiplex/fractal/fuse_touching_labels.py
@@ -153,7 +153,9 @@ def fuse_touching_labels(
     else:
         output_label_name = new_label_name
 
-    new_label_container = ome_zarr.derive_label(name=output_label_name, overwrite=True)
+    new_label_container = ome_zarr.derive_label(
+        name=output_label_name, ref_image=label_img_to_fuse, overwrite=True
+    )
 
     # Rechunk if necessary
     target_chunks = new_label_container.chunks

--- a/src/scmultiplex/fractal/post_registration_cleanup.py
+++ b/src/scmultiplex/fractal/post_registration_cleanup.py
@@ -286,10 +286,12 @@ def post_registration_cleanup(
             )
 
             label_image = source_ome_zarr.get_label(name=label_name)
-            new_label = target_ome_zarr.derive_label(
-                new_label_name, overwrite=overwrite_labels_and_tables
-            )
             label_image_dask = label_image.get_array(mode="dask")
+            new_label = target_ome_zarr.derive_label(
+                new_label_name,
+                dtype=label_image_dask.dtype,
+                overwrite=overwrite_labels_and_tables,
+            )
             new_label.set_array(label_image_dask)
             new_label.consolidate()
 
@@ -389,13 +391,12 @@ def post_registration_cleanup(
             )
 
             label_image = source_ome_zarr.get_label(name=label_name)
+            label_image_dask = label_image.get_array(mode="dask")
             new_label = target_ome_zarr.derive_label(
                 label_name,
-                dtype=np.uint32,
+                dtype=label_image_dask.dtype,
                 overwrite=overwrite_labels_and_tables_from_ref,
             )
-            label_image_dask = label_image.get_array(mode="dask")
-            logger.info(f"Datatype of label image: {label_image_dask.dtype}")
             new_label.set_array(label_image_dask)
             new_label.consolidate()
 

--- a/src/scmultiplex/fractal/shift_by_rigid_shift.py
+++ b/src/scmultiplex/fractal/shift_by_rigid_shift.py
@@ -225,7 +225,7 @@ def shift_by_rigid_shift(
             save_name = shifted_name
 
         new_label = moving_ome_zarr.derive_label(
-            name=save_name, overwrite=overwrite_label
+            name=save_name, dtype=label_volume_dask.dtype, overwrite=overwrite_label
         )
 
         # Apply 2D rigid transformation by z slice in each z-block, resize, write each chunk to disk

--- a/src/scmultiplex/fractal/shift_by_shift.py
+++ b/src/scmultiplex/fractal/shift_by_shift.py
@@ -190,7 +190,7 @@ def shift_by_shift(
         new_shifted_label_name = label_name_to_shift + "_shifted"
 
     new_label_container = moving_ome_zarr.derive_label(
-        name=new_shifted_label_name, overwrite=True
+        name=new_shifted_label_name, dtype=img_array.dtype, overwrite=True
     )
     new_label_container.set_array(shifted_img_array)
 


### PR DESCRIPTION
- Prevent clipping uint32 to uint16 by deriving label from reference image or pass dtype, depending on task function. Apply fix to all tasks that use NGIO derive.